### PR TITLE
cmdchClose changed to expect device instead of fd

### DIFF
--- a/cbm/cmd/del.asm
+++ b/cbm/cmd/del.asm
@@ -10,6 +10,7 @@ jmp removeMain
 ;*** global declarations
 
 libwork = $60
+rmErrno = libwork  ;(4) zero-extended errno for aceMiscUtoa
 
 chrQuote = $22
 
@@ -81,13 +82,38 @@ rmError = *
    jsr eputs
    lda #<rmErrorMsg2
    ldy #>rmErrorMsg2
+   jsr eputs
+   ;** print errno (decimal) followed by CR
+   lda errno
+   sta rmErrno+0
+   lda #0
+   sta rmErrno+1
+   sta rmErrno+2
+   sta rmErrno+3
+   lda #<rmNumbuf
+   ldy #>rmNumbuf
+   sta zp
+   sty zp+1
+   ldx #rmErrno
+   lda #1
+   jsr aceMiscUtoa
+   lda #<rmNumbuf
+   ldy #>rmNumbuf
+   jsr eputs
+   lda #<rmErrorMsg3
+   ldy #>rmErrorMsg3
    jmp eputs
+
+rmNumbuf !fill 12,0
 
 rmErrorMsg1 = *
    !pet "Error attempting to remove ",chrQuote,0
 
 rmErrorMsg2 = *
-   !pet chrQuote,chrCR,0
+   !pet chrQuote,", code ",0
+
+rmErrorMsg3 = *
+   !pet chrCR,0
 
 rmEcho = *
    lda #<rmEchoMsg1

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -286,9 +286,7 @@ cmdchOpen = *  ;( .A=device )
    sta errno
 +  rts
 
-cmdchClose = *
-   lda devtable,x
-   tax
+cmdchClose = *  ;( .X=device, matches cmdchOpen's convention )
    lda configBuf+0,x
    cmp #1
    beq +
@@ -367,6 +365,7 @@ checkDiskStatus = *
 +  cmp #20
    bcc +
    sta errno
+   ;carry already set: bcc above didn't branch, so C=1 from the cmp #20
 +  rts
 
 
@@ -385,6 +384,8 @@ internClose = *
    lda lftable,x
    cmp #cmdlf
    bne +
+   lda devtable,x  ;cmdchClose now takes .X=device, translate fd->device here
+   tax
    jmp cmdchClose
 +  lda pidtable,x
    cmp aceProcessID
@@ -704,6 +705,7 @@ bSlash:
    bcs +
    jsr checkDiskStatus
 +  php
+   ldx removeDevice   ;cmdchClose needs .X=device, not leftover X
    jsr cmdchClose
    plp
 ++ rts
@@ -768,6 +770,7 @@ kernFileRename = *
    bcs +
    jsr checkDiskStatus
 +  php
+   ldx renameDevice  ;cmdchClose needs .X=device, not leftover X
    jsr cmdchClose
    plp
 ++ rts
@@ -1472,6 +1475,7 @@ internDirChange = *
    bcs chdirAbort
    jsr checkDiskStatus
    bcs chdirAbort
+   ldx chdirDevice  ;cmdchClose needs .X=device, not leftover X
    jsr cmdchClose
    lda #0
    sta stringBuffer+2
@@ -1491,6 +1495,7 @@ internDirChange = *
    rts
 
    chdirAbort = *
+   ldx chdirDevice  ;cmdchClose needs .X=device, not leftover X
    jsr cmdchClose
    sec
    rts
@@ -1528,6 +1533,7 @@ kernIecCommand = *
    bne -
    clc
 +  php
+   ldx aceCurrentDevice  ;cmdchClose needs .X=device, not leftover X
    jsr cmdchClose
    plp
 ++ rts


### PR DESCRIPTION
kernel

- cmdchClose now accepts device instead of fd in X as only one invocation was passing fd, most don't even have it
- all calls now set X with appropriate device

del command
- will output numeric error code

This fixes deleting second file.