### PR TITLE
Modular iec

### DIFF
--- a/cbm/Makefile
+++ b/cbm/Makefile
@@ -12,7 +12,8 @@ sys/acehead.asm sys/kernhead.asm sys/acemacro.asm sys/toolhead.asm
 
 ACEDRVS=\
 sys/acevdc.asm sys/acevic.asm sys/acesoft80.asm idun-io.asm \
-sys/acepid.asm sys/acepiserv.asm sys/hook.asm
+sys/acepid.asm sys/acepiserv.asm sys/hook.asm sys/acemioc64.asm \
+sys/acemionone.asm
 
 KERNEL=$(SYSDIR)/idun128 \
 $(SYSDIR)/idun-64

--- a/cbm/Makefile
+++ b/cbm/Makefile
@@ -12,7 +12,7 @@ sys/acehead.asm sys/kernhead.asm sys/acemacro.asm sys/toolhead.asm
 
 ACEDRVS=\
 sys/acevdc.asm sys/acevic.asm sys/acesoft80.asm idun-io.asm \
-sys/acepid.asm sys/acepiserv.asm sys/hook.asm sys/acemioc64.asm \
+sys/acepid.asm sys/acepiserv.asm sys/hook.asm sys/acemiocbm.asm \
 sys/acemionone.asm
 
 KERNEL=$(SYSDIR)/idun128 \

--- a/cbm/sys/ace.asm
+++ b/cbm/sys/ace.asm
@@ -34,6 +34,11 @@
 !source "sys/kernhead.asm"
 !source "sys/acemacro.asm"
 
+!ifdef useIec {
+} else {
+   useIec = 1  ;;IEC/serial-bus drive support; 0 for targets with no IEC bus (e.g. Mega65)
+}
+
 !if computer-64 {
    useC128 = 1
    useC64  = 0
@@ -787,6 +792,11 @@ brkHandler = *
 
 ;These drivers in lower memory space
 !source "sys/acecall.asm"
+!if useIec {
+   !source "sys/acemioc64.asm"
+} else {
+   !source "sys/acemionone.asm"
+}
 !source "idun-io.asm"
 
 aceExitBasic = *

--- a/cbm/sys/ace.asm
+++ b/cbm/sys/ace.asm
@@ -394,6 +394,9 @@ jmp kernSearchPath
 
 notImp = *
    lda #aceErrNotImplemented
+   ; Intentional fall through
+
+rtsCarryErrno = *
    sta errno
    sec
    rts

--- a/cbm/sys/ace.asm
+++ b/cbm/sys/ace.asm
@@ -361,8 +361,8 @@ jmp kernTimeSetDate
 jmp kernIrqHook
 
 jmp kernMiscUtoa
-jmp kernMiscIoPeek
-jmp kernMiscIoPoke
+jmp notImp
+jmp notImp
 
 jmp kernFileFdswap
 jmp kernConRead

--- a/cbm/sys/ace.asm
+++ b/cbm/sys/ace.asm
@@ -34,9 +34,9 @@
 !source "sys/kernhead.asm"
 !source "sys/acemacro.asm"
 
-!ifdef useIec {
+!ifdef useMioCbm {
 } else {
-   useIec = 1  ;;IEC/serial-bus drive support; 0 for targets with no IEC bus (e.g. Mega65)
+   useMioCbm = 1  ;;IEC/serial-bus drive & printer support using CBM kernal
 }
 
 !if computer-64 {
@@ -795,8 +795,8 @@ brkHandler = *
 
 ;These drivers in lower memory space
 !source "sys/acecall.asm"
-!if useIec {
-   !source "sys/acemioc64.asm"
+!if useMioCbm {
+   !source "sys/acemiocbm.asm"
 } else {
    !source "sys/acemionone.asm"
 }

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -470,10 +470,8 @@ removeDevice = syswork+0
 ;*** aceFileRemove( (zp)=Name )
 kernFileRemove = *
 internRemove = *
-   jsr getDiskDevice
-   bcc +
-   rts
-+  sta removeDevice
+   jsr getDiskDevice     ;bails out of this call on non-disk device
+   sta removeDevice
    sty openNameScan
    ; IDUN: Type #1. Call MOS
    cpx #1
@@ -496,10 +494,8 @@ renameDevice = syswork+0
 ;*** aceFileRename( (zp)=OldName, (zw)=NewName )
 ;*** don't even think about renaming files outside the current directory
 kernFileRename = *
-   jsr getDiskDevice
-   bcc +
-   rts
-+  sta renameDevice
+   jsr getDiskDevice     ;bails out of this call on non-disk device
+   sta renameDevice
    sty openNameScan
    ; IDUN: Type #1. Call MOS
    cpx #1
@@ -729,10 +725,8 @@ kernFileFdswap = *
 kernDirOpen = *
    lda #false
    sta checkStat
-   jsr getDiskDevice
-   bcc +
-   rts
-+  sta openDevice
+   jsr getDiskDevice     ;bails out of this call on non-disk device
+   sta openDevice
    sty openNameScan
    cpx #1               ;IEC device?
    bne +                ;no: virtual
@@ -830,10 +824,8 @@ internDirChange = *
    ldy #>configBuf+$80
    sta zp+0
    sty zp+1
-++ jsr getDiskDevice
-   bcc +
-   rts
-+  sty chdirNameScan
+++ jsr getDiskDevice     ;bails out of this call on non-disk device
+   sty chdirNameScan
    sta chdirDevice
    ; IDUN: Replace with acepid for virtual drives/floppies.
    cpx #4
@@ -1336,6 +1328,9 @@ getLfAndFcb = * ;() : .X=fcb, .A=lf
    rts
 
 getDiskDevice = *  ;( (zp)=devname ) : .A=device, .Y=scan, .X=dev_t, .CC=isDisk
+   ; on failure this pops its own return address and bails out of
+   ; the *caller* too (.CS/errno set) - callers just "jsr getDiskDevice"
+   ; with no bcc/rts needed; only reachable on success
    jsr getDevice
    pha
    tax
@@ -1350,6 +1345,10 @@ getDiskDevice = *  ;( (zp)=devname ) : .A=device, .Y=scan, .X=dev_t, .CC=isDisk
    beq -
    cmp #7
    beq -
+   pla                     ;discard saved device idx
+   ; not a disk: pop our own return address so this rts drops
+   ; straight back to our caller's caller, bailing it out too
+   pla
    pla
    lda #aceErrDiskOnlyOperation
    sta errno

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -8,18 +8,6 @@
 
 kernelSetbnk = $ff68
 
-;-- mioUnsupported: fallback for the +jmpMio macro when useIec=0 -- reached
-;   only if a device is (mis)configured as an IEC drive on a build with no
-;   IEC support. sys/acemionone.asm aliases every mio* entry point to
-;   this label when useIec=0, so +jmpMio's `jmp .label` always resolves
-;   (ACME evaluates macro arguments eagerly, so the label must be defined
-;   in every build, not just conditionally jumped to)
-mioUnsupported = *
-   lda #aceErrIllegalDevice
-   sta errno
-   sec
-   rts
-
 ;====== file calls ======
 
 ;*** open( zp=filenameZ, .A=mode["r","w","a","W","A"] ) : .A=fcb
@@ -177,7 +165,7 @@ internOpen = *
    lda configBuf+0,y
    cmp #1
    bne nonDiskOpen
-   +jmpMio mioOpenNameSuffix
+   jmp mioOpenNameSuffix
 
    ;** get rid of the filename for non-disks
    nonDiskOpen = *
@@ -311,7 +299,7 @@ internClose = *
    bne +
    jsr pidClose
    jmp closeFdEntry
-+  +jmpMio mioClosePath
++  jmp mioClosePath
 
    closeFdEntry = *
    ldx closeFd
@@ -386,7 +374,7 @@ kernFileRead = *
    bne +
    ldy #$ff
 +  }
-   +jmpMio mioReadPath
+   jmp mioReadPath
 
    readExit = *
    jsr kernelClrchn
@@ -452,7 +440,7 @@ internWrite = *
    bne +
    clc
    rts
-+  +jmpMio mioWritePath
++  jmp mioWritePath
 
 ;NAME   :  seek
 ;PURPOSE:  seek to file location
@@ -499,16 +487,13 @@ internRemove = *
    rts
 +  sta removeDevice
    sty openNameScan
+   ; IDUN: Type #1. Call MOS
+   cpx #1
+   bne +
+   jmp mioRemovePath
    ; IDUN: Type #4/7. Replace with acepid.
-   cpx #4
-   bne +
-   ldx removeDevice
++  ldx removeDevice
    jmp pidRemove
-+  cpx #7
-   bne +
-   ldx removeDevice
-   jmp pidRemove
-+  +jmpMio mioRemovePath
 
 
 ;NAME   :  aceFileRename
@@ -519,7 +504,6 @@ internRemove = *
 ;ALTERS :  .A, .X, .Y, errno
 
 renameDevice = syswork+0
-renameScan   = syswork+1
 
 ;*** aceFileRename( (zp)=OldName, (zw)=NewName )
 ;*** don't even think about renaming files outside the current directory
@@ -529,17 +513,13 @@ kernFileRename = *
    rts
 +  sta renameDevice
    sty openNameScan
+   ; IDUN: Type #1. Call MOS
+   cpx #1
+   bne +
+   jmp mioRenamePath
    ; IDUN: Type #4/7. Replace with acepid.
-   cpx #4
-   bne +
-   ldx renameDevice
++  ldx renameDevice
    jmp pidRename
-+  cpx #7
-   bne +
-   ldx renameDevice
-   jmp pidRename
-+  sty renameScan
-   +jmpMio mioRenamePath
 
 
 ;NAME   :  aceFileBload/aceFileBkload
@@ -601,12 +581,10 @@ internBload = *
 +  cmp #5
    bne +
    jmp internTagBload
-+  !if useIec {
    cmp #1
    bne +
    jmp mioBloadPath
-+  }
-   lda #aceErrIllegalDevice
++  lda #aceErrIllegalDevice
    sta errno
    sec
    rts
@@ -691,7 +669,7 @@ fstatRespHandler = *
 ;   does not touch syswork+3
 fstatFcb = syswork+3
 mioFileStatEntry = *
-   +jmpMio mioFileStat
+   jmp mioFileStat
 
 ;-- fcbSetup: allocate FCB; fill lftable/devtable/eoftable/satable/openFcb
 ;   ( openDevice=set ) : .X=fcb, .CS=error
@@ -812,7 +790,7 @@ kernDirRead = *
 +  cmp #7
    bne +
    jmp pidDirRead
-+  +jmpMio mioDirRead
++  jmp mioDirRead
 
 ;*** aceDirIsdir( (zp)=FilenameZ ) : .A=Dev, .X=isDisk, .Y=isDir
 
@@ -883,7 +861,7 @@ internDirChange = *
    bne +
    ldx chdirDevice
    jmp pidChDir
-+  +jmpMio mioChdirPath
++  jmp mioChdirPath
 
 ;-- chdirSetName: commit chdirDevice as the new current directory; shared by
 ;   the IEC path (mioChdirPath, acemioc64.asm) and pidChDir (acepid.asm)
@@ -905,7 +883,7 @@ chdirSetName = *
 ;*** aceIecCommand( (zp)=Command )
 
 kernIecCommand = *
-   +jmpMio mioIecCommand
+   jmp mioIecCommand
 
 ;*** aceDirName( .A=sysdir, (zp)=buf, .Y=assignLen ) : buf, .Y=len
 ;***   .A : 0=curDir, 1=homedir, 2=execSearchPath, 3=configSearchPath, 4=tempDir

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -8,6 +8,18 @@
 
 kernelSetbnk = $ff68
 
+;-- mioUnsupported: fallback for the +jmpMio macro when useIec=0 -- reached
+;   only if a device is (mis)configured as an IEC drive on a build with no
+;   IEC support. sys/acemionone.asm aliases every mio* entry point to
+;   this label when useIec=0, so +jmpMio's `jmp .label` always resolves
+;   (ACME evaluates macro arguments eagerly, so the label must be defined
+;   in every build, not just conditionally jumped to)
+mioUnsupported = *
+   lda #aceErrIllegalDevice
+   sta errno
+   sec
+   rts
+
 ;====== file calls ======
 
 ;*** open( zp=filenameZ, .A=mode["r","w","a","W","A"] ) : .A=fcb
@@ -98,8 +110,11 @@ internOpen = *
    jmp nonDiskSa
 +  ldy #0
    ;** check native disk device
+!if useIec {
    cmp #1
-   beq openDiskSa
+   bne +
+   jmp mioOpenDiskSa
++  }
    ;** check console
    cmp #2
    bne +
@@ -144,25 +159,6 @@ internOpen = *
    sec
    rts
 
-   openDiskSa = *
-   lda #true
-   sta checkStat
-   ldy #2
-   diskSaSearch = *
-   ldx #fcbCount-1
--  lda lftable,x
-   bmi +
-   lda devtable,x
-   cmp openDevice
-   bne +
-   tya
-   cmp satable,x
-   bne +
-   iny
-   bne diskSaSearch
-+  dex
-   bpl -
-
    nonDiskSa = *
    ldx openFcb
    tya
@@ -181,21 +177,7 @@ internOpen = *
    lda configBuf+0,y
    cmp #1
    bne nonDiskOpen
-   ;** stick the mode for disk files
-   cpx #0
-   bne +
-   lda #aceErrOpenDirectory
-   sec
-   rts
-+  +ldaSCII ","
-   sta stringBuffer,x
-   inx
-   lda openMode
-   sta stringBuffer,x
-   inx
-   lda #0
-   sta stringBuffer,x
-   jmp openGotName
+   +jmpMio mioOpenNameSuffix
 
    ;** get rid of the filename for non-disks
    nonDiskOpen = *
@@ -224,13 +206,17 @@ internOpen = *
    ;do the open
    jsr kernelOpen
    bcs openError
-+  ldx openDevice
+!if useIec {
+   ldx openDevice
    lda configBuf+0,x
    cmp #1
-   bne +
+   bne openSuccess
    txa
-   jsr openDiskStatus
-   bcc +
+   jsr mioOpenDiskStatus
+   bcc openSuccess
+} else {
+   jmp openSuccess
+}
 
    openError = *
    sta errno
@@ -244,129 +230,32 @@ internOpen = *
    sec
    lda #fcbNull
    rts
-+  lda openFcb
+   openSuccess = *
+   lda openFcb
    clc
    rts
-
-openDiskStatus = *  ;( .A=device ) : errno=.A=errcode, .CS=errflag
-   bit checkStat
-   bne +
-   clc
-   rts
-+  sta diskStatusDev ;temp. store device here!
-   jsr cmdchOpen
-   bcc +
-   cmp #aceErrFileOpen
-   bne ++
-+  jsr checkDiskStatus
-   php
-   pha
-   ldx diskStatusDev
-   jsr cmdchClose
-   pla
-   plp
-++ rts
-diskStatusDev !byte 0
-
-cmdchOpen = *  ;( .A=device )
-   ; pha
-   ; jsr cmdchClose
-   ; pla
-   tax
-   lda configBuf+2,x
-   tay
-   lda configBuf+1,x
-   tax
-   lda #cmdlf
-   jsr kernelSetlfs
-   lda #0
-   jsr kernelSetnam
-   jsr kernelOpen
-   bcc +
-   sta errno
-+  rts
 
 cmdchClose = *  ;( .X=device, matches cmdchOpen's convention )
    lda configBuf+0,x
    cmp #1
-   beq +
+   beq cmdchClosePhysical
    lda configBuf+2,x
    sta closeFd
    jmp pidClose
-+  sec
+   cmdchClosePhysical = *
+!if useIec {
+   sec
    lda #cmdlf
    jsr kernelClose
    bcc +
    sta errno
 +  rts
-
-cmdchSend = *  ;( stringBuffer )
-   ldx #cmdlf
-   jsr kernelChkout
-   bcs cmdchErr
-   ldx #0
--  lda stringBuffer,x
-   beq +
-   jsr kernelChrout
-   bcs cmdchErr
-   inx
-   bne -
-+  jsr kernelClrchn
-   clc
-   rts
-
-   cmdchErr = *
-   sta errno
-   pha
-   jsr kernelClrchn
-   pla
-   sec
-   rts
-
-checkDiskStatusCode !byte 0
-
-checkDiskStatus = *
-   ldx #cmdlf
-   jsr kernelChkin
-   bcs cmdchErr
-   jsr kernelChrin
-   bcs cmdchErr
-   and #$0f
-   sta checkDiskStatusCode
-   asl
-   asl
-   adc checkDiskStatusCode
-   asl
-   sta checkDiskStatusCode
-   jsr kernelChrin
-   bcs cmdchErr
-   and #$0f
-   clc
-   adc checkDiskStatusCode
-   sta checkDiskStatusCode
--  jsr kernelReadst
-   and #$80
-   beq +
-   lda #aceErrDeviceNotPresent
-   sec
-   bcs cmdchErr
-+  jsr kernelChrin
-   bcs cmdchErr
-   cmp #chrCR
-   bne -
-   jsr kernelClrchn
-   lda checkDiskStatusCode
-   cmp #62
-   bne +
-   lda #aceErrFileNotFound
+} else {
+   lda #aceErrIllegalDevice
    sta errno
    sec
    rts
-+  cmp #20
-   bcc +
-   sta errno
-   ;carry already set: bcc above didn't branch, so C=1 from the cmp #20
-+  rts
+}
 
 
 ;NAME   :  close
@@ -422,10 +311,7 @@ internClose = *
    bne +
    jsr pidClose
    jmp closeFdEntry
-+  ldx closeFd
-   lda lftable,x
-   clc
-   jsr kernelClose
++  +jmpMio mioClosePath
 
    closeFdEntry = *
    ldx closeFd
@@ -495,40 +381,12 @@ kernFileRead = *
    sty zw+1
    clc
    rts
-+  cmp #1
++  !if useIec {
+   cmp #1
    bne +
    ldy #$ff
-+  ldx readFcb
-   sty readDeviceDisk
-   lda lftable,x
-   tax
-   jsr kernelChkin
-   bcc readByte
-   sta errno
-   rts
-   
-   readByte = *
-   lda readLength+0
-   cmp readMaxLen+0
-   lda readLength+1
-   sbc readMaxLen+1
-   bcs readExit
-   jsr kernelChrin
-   ldy #0
-   sta (readPtr),y
-   inc readPtr+0
-   bne +
-   inc readPtr+1
-+  inc readLength+0
-   bne +
-   inc readLength+1
-+  bit readDeviceDisk
-   bpl readByte
-   lda st
-   and #$40
-   beq readByte
-   ldx readFcb
-   sta eoftable,x
++  }
+   +jmpMio mioReadPath
 
    readExit = *
    jsr kernelClrchn
@@ -594,38 +452,7 @@ internWrite = *
    bne +
    clc
    rts
-+  ldx regsave+1
-   lda lftable,x
-   tax
-   jsr kernelChkout
-   bcc writeByte
-   rts
-
-   writeByte = *
-   lda writeLength+0
-   ora writeLength+1
-   beq writeFinish
-   ldy #0
-   lda (writePtr),y
-   jsr kernelChrout
-   bcc +
-   sta errno
-   jsr kernelClrchn
-   sec
-   rts
-+  inc writePtr+0
-   bne +
-   inc writePtr+1
-+  lda writeLength+0
-   bne +
-   dec writeLength+1
-+  dec writeLength+0
-   jmp writeByte
-   
-   writeFinish = *
-   jsr kernelClrchn
-   clc
-   rts
++  +jmpMio mioWritePath
 
 ;NAME   :  seek
 ;PURPOSE:  seek to file location
@@ -647,8 +474,9 @@ kernFileLseek = *
    lda configBuf+0,x
    ;seek only suppoorted by mem-mapped files (#5)
    cmp #5
-   bne +
+   bne lseekIllegal
    jmp internTagSeek
+   lseekIllegal = *
    lda #aceErrIllegalDevice
    sta errno
    sec
@@ -680,35 +508,7 @@ internRemove = *
    bne +
    ldx removeDevice
    jmp pidRemove
-+  +ldaSCII "s"
-   sta stringBuffer
-   +ldaSCII ":"
-   sta stringBuffer+1
-   ldx #1
-   lda (zp),y
-   +cmpASCII "/"
-   beq bSlash
-   ldx #2
-bSlash:
-   lda (zp),y
-   sta stringBuffer,x
-   beq +
-   iny
-   inx
-   bne bSlash
-+  lda #0
-   sta stringBuffer,x
-   lda removeDevice
-   jsr cmdchOpen
-   bcs ++
-   jsr cmdchSend
-   bcs +
-   jsr checkDiskStatus
-+  php
-   ldx removeDevice   ;cmdchClose needs .X=device, not leftover X
-   jsr cmdchClose
-   plp
-++ rts
++  +jmpMio mioRemovePath
 
 
 ;NAME   :  aceFileRename
@@ -739,41 +539,7 @@ kernFileRename = *
    ldx renameDevice
    jmp pidRename
 +  sty renameScan
-   +ldaSCII "r"
-   sta stringBuffer+0
-   +ldaSCII ":"
-   sta stringBuffer+1
-   ;** copy new name
-   ldy #0
-   ldx #2
--  lda (zw),y
-   sta stringBuffer,x
-   beq +
-   iny
-   inx
-   bne -
-+  +ldaSCII "="
-   sta stringBuffer,x
-   inx
-   ;** copy old name
-   ldy renameScan
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   inx
-   iny
-   bne -
-+  lda renameDevice
-   jsr cmdchOpen
-   bcs ++
-   jsr cmdchSend
-   bcs +
-   jsr checkDiskStatus
-+  php
-   ldx renameDevice  ;cmdchClose needs .X=device, not leftover X
-   jsr cmdchClose
-   plp
-++ rts
+   +jmpMio mioRenamePath
 
 
 ;NAME   :  aceFileBload/aceFileBkload
@@ -835,66 +601,14 @@ internBload = *
 +  cmp #5
    bne +
    jmp internTagBload
-+  cmp #1
-   beq +
++  !if useIec {
+   cmp #1
+   bne +
+   jmp mioBloadPath
++  }
    lda #aceErrIllegalDevice
    sta errno
    sec
-   rts
-+  lda #true
-   sta checkStat
-   lda configBuf+1,x
-   tax
-   lda #0
-   ldy #0
-   jsr kernelSetlfs
-   ldy #0
--  lda (bloadFilename),y
-   beq +
-   iny
-   bne -
-+  tya
-   ldx bloadFilename+0
-   ldy bloadFilename+1
-   jsr kernelSetnam
-!if useC128 {
-   lda bloadBank
-   beq +
-   ldx #0
-   jsr kernelSetbnk
-}
-+  lda #0
-   ldx bloadAddress+0
-   ldy bloadAddress+1
-   jsr kernelLoad
-   bcc bloadOk
-   pha
-   cmp #aceErrDeviceNotPresent
-   beq +
-   ldx bloadDevice
-   lda configBuf+0,x
-   cmp #1
-   bne +
-   txa
-   jsr openDiskStatus
-+  pla
--  sta errno
-   lda #0
-   ldx #0
-   ldy #0
-   sec
-   rts
-
-   bloadOk = *
-   ldx bloadDevice
-   lda configBuf+0,x
-   cmp #1
-   bne +
-   txa
-   jsr openDiskStatus
-   bcs -
-+  lda bloadAddress+0
-   ldy bloadAddress+1
    rts
 
 ;*** aceDirStat ( .A=stat, (zp)=path ) : CS=error,errno
@@ -943,7 +657,7 @@ dstatRespHandler = *
 
 kernFileStat = *
    jsr kernMiscDeviceInfo
-   bcc iecFileStat
+   bcc mioFileStatEntry
    lda syswork+1
    sta openDevice
    lda #"r"
@@ -973,50 +687,11 @@ fstatRespHandler = *
    ldy aceDirentBytes+1
    rts
 
-;-- iecFileStat: IEC path for aceFileStat
-;   opens filtered dir "$:BASENAME", reads one entry into aceDirentBuffer
-fstatFcb = syswork+3  ; scratch; kernDirRead does not touch syswork+3
-iecFileStat = *
-   +ldaSCII "$"
-   sta stringBuffer+0
-   +ldaSCII ":"
-   sta stringBuffer+1
-   ldy #0
--  lda (zp),y
-   beq fsIECNotFound
-   iny
-   cmp #<":"
-   bne -
-   ldx #2
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   iny
-   inx
-   bne -
-+  lda syswork+1
-   sta openDevice
-   jsr iecDirOpen      ; .A = fcb
-   bcs fsIECRts
-   sta fstatFcb        ; kernDirRead clobbers openFcb=syswork+0 via dirBlocks
-   tax
-   jsr kernDirRead    ; skip disk name header entry
-   ldx fstatFcb
-   jsr kernDirRead    ; read actual file entry
-   php
-   lda fstatFcb
-   jsr kernDirClose
-   plp
-   bcs fsIECRts
-   bne +
-fsIECNotFound = *
-   lda #aceErrFileNotFound
-   sta errno
-fsIECRts = *
-   sec
-   rts
-+  clc
-   rts
+;-- fstatFcb: scratch shared with mioFileStat (acemioc64.asm); kernDirRead
+;   does not touch syswork+3
+fstatFcb = syswork+3
+mioFileStatEntry = *
+   +jmpMio mioFileStat
 
 ;-- fcbSetup: allocate FCB; fill lftable/devtable/eoftable/satable/openFcb
 ;   ( openDevice=set ) : .X=fcb, .CS=error
@@ -1031,32 +706,6 @@ fcbSetup = *
    sta satable,x
    stx openFcb
 +  rts
-
-;-- iecDirOpen: open IEC filtered dir with pre-built name in stringBuffer
-;   ( openDevice=set, .X=name length ) : .A=fd, .CC
-iecDirOpen = *
-   stx openNameLength
-   jsr fcbSetup
-   bcc +
-   rts
-+  lda #true
-   sta checkStat
-   lda openDevice
-   jsr openDiskStatus
-   ldx openNameLength
-   jsr openGotName
-   bcc +
-   rts
-+  ldx openFcb
-   lda lftable,x
-   tax
-   jsr kernelChkin
-   jsr kernelChrin
-   jsr kernelChrin
-   jsr kernelClrchn
-   lda openFcb
-   clc
-   rts
 
 ;*** aceFileIoctl ( .X=virt. device, (zp)=io cmd ) : .CS=error,errno
 
@@ -1119,13 +768,15 @@ kernDirOpen = *
    rts
 +  sta openDevice
    sty openNameScan
+!if useIec {
    cpx #1               ;IEC device?
    bne +                ;no: virtual
    +ldaSCII "$"
    sta stringBuffer+0
    ldx #1
-   jmp iecDirOpen
-+  jsr fcbSetup         ;virtual: allocate FCB then dispatch
+   jmp mioDirOpen
++  }
+   jsr fcbSetup         ;virtual: allocate FCB then dispatch
    bcc +
    rts
 +  jmp pidDirOpen
@@ -1145,8 +796,6 @@ kernDirClose = *
 
 ;*** aceDirRead( .X=fcb ) : .Z=eof, aceDirentBuffer=data
 
-dirBlocks = syswork+0
-
 kernDirRead = *
    ; ensure aceDirentBytes is zero
    lda #0
@@ -1163,223 +812,7 @@ kernDirRead = *
 +  cmp #7
    bne +
    jmp pidDirRead
-+  lda lftable,x
-   tax
-   jsr kernelChkin
-   bcc +
-   lda #0
-   rts
-   ;** read the link
-+  jsr kernelChrin
-   sta syswork+4
-   jsr kernelReadst
-   and #$40
-   bne dirreadEofExit
-   jsr kernelChrin
-   ora syswork+4
-   bne +
-
-   dirreadEofExit = *
-   jsr kernelClrchn
-   ldx #0
-   rts
-   dirreadErrExit = *
-   sta errno
-   jsr kernelClrchn
-   ldx #0
-   sec
-   rts
-
-   ;** read the block count
-+  jsr kernelChrin
-   sta dirBlocks
-   sta aceDirentBytes+1
-   jsr kernelChrin
-   sta dirBlocks+1
-   sta aceDirentBytes+2
-   asl dirBlocks
-   rol dirBlocks+1
-   lda #0
-   rol
-   sta dirBlocks+2
-   sec
-   lda #0
-   sbc dirBlocks
-   sta aceDirentBytes+0
-   lda aceDirentBytes+1
-   sbc dirBlocks+1
-   sta aceDirentBytes+1
-   lda aceDirentBytes+2
-   sbc dirBlocks+2
-   sta aceDirentBytes+2
-   ;** read the filename
-   lda #0
-   sta aceDirentName
-   sta aceDirentNameLen
--  jsr kernelChrin
-   bcs dirreadErrExit
-   bit st
-   bvs dirreadErrExit
-   +cmpASCII " "
-   beq -
-   cmp #18
-   beq -
-   cmp #$22
-   bne dirreadExit
-   ldx #0
--  jsr kernelChrin
-   bcs dirreadErrExit
-   bit st
-   bvs dirreadErrExit
-   cmp #$22
-   beq +
-   sta aceDirentName,x
-   inx
-   bne -
-+  lda #0
-   sta aceDirentName,x
-   stx aceDirentNameLen
--  jsr kernelChrin
-   +cmpASCII " "
-   beq -
-   ;** read type and flags
-   ldx #%01100000
-   stx aceDirentFlags
-   ldx #%10000000
-   stx aceDirentUsage
-   +cmpASCII "*"
-   bne +
-   lda aceDirentFlags
-   ora #%00001000
-   sta aceDirentFlags
-   jsr kernelChrin
-+  ldx #3
-   ldy #0
-   jmp dirTypeFirst
--  jsr kernelChrin
-   dirTypeFirst = *
-   sta aceDirentType,y
-   iny
-   dex
-   bne -
-   lda #0
-   sta aceDirentType+3
-   lda aceDirentType
-   +cmpASCII "d"
-   bne +
-   lda aceDirentFlags
-   ora #%10010000
-   sta aceDirentFlags
-   jmp dirreadExit
-+  +cmpASCII "p"
-   bne dirreadExit
-   lda aceDirentFlags
-   ora #%00010000
-   sta aceDirentFlags
-   jmp dirreadExit
-
-   dirreadExit = *
-   jsr kernelChrin
-   cmp #0
-   bne +
-   jmp dirreadRealExit
-+  +cmpASCII "<"
-   bne +
-   lda aceDirentFlags
-   and #%11011111
-   sta aceDirentFlags
-+  ldx #7
-   lda #0
--  sta aceDirentDate,x
-   dex
-   bpl -
--  jsr kernelChrin
-   cmp #0
-   beq dirreadRealExit
-   +cmpASCII "0"
-   bcc -
-   cmp #$3a
-   bcs -
-
-   dirreadDate = *
-   jsr dirGetNumGot
-   bcs dirreadRealExit
-   sta aceDirentDate+2
-   jsr dirGetNum
-   bcs dirreadRealExit
-   sta aceDirentDate+3
-   jsr dirGetNum
-   bcs dirreadRealExit
-   sta aceDirentDate+1
-   ldx #$19
-   cmp #$70
-   bcs +
-   ldx #$20
-+  stx aceDirentDate+0  ;century
-   jsr dirGetNum
-   bcs dirreadRealExit
-   sta aceDirentDate+4
-   jsr dirGetNum
-   bcs dirreadRealExit
-   sta aceDirentDate+5
-   jsr kernelChrin
-   and #$ff
-   beq dirreadRealExit
-   jsr kernelChrin
-   and #$ff
-   beq dirreadRealExit
-   +cmpASCII "a"
-   bne dirreadPM
-
-   dirreadAM = *
-   lda aceDirentDate+4
-   cmp #$12
-   bne +
-   lda #$00
-   sta aceDirentDate+4
-   jmp +
-
-   dirreadPM = *
-   lda aceDirentDate+4
-   cmp #$12
-   beq dirReadInternBr
-   clc
-   sed
-   adc #$12
-   cld
-   sta aceDirentDate+4
-dirReadInternBr:
-   jsr kernelChrin
-   cmp #0
-   bne dirReadInternBr
-
-   dirreadRealExit = *
-   jsr kernelClrchn
-   ldx #$ff
-   clc
-   rts
-
-   dirGetNum = *
--  jsr kernelChrin
-   dirGetNumGot = *
-   cmp #0
-   beq +
-   +cmpASCII "0"
-   bcc -
-   cmp #$3a
-   bcs -
-   asl
-   asl
-   asl
-   asl
-   sta syswork+6
-   jsr kernelChrin
-   cmp #0
-   beq +
-   and #$0f
-   ora syswork+6
-   clc
-+  rts
++  +jmpMio mioDirRead
 
 ;*** aceDirIsdir( (zp)=FilenameZ ) : .A=Dev, .X=isDisk, .Y=isDir
 
@@ -1450,37 +883,12 @@ internDirChange = *
    bne +
    ldx chdirDevice
    jmp pidChDir
-+  +ldaSCII "c"
-   sta stringBuffer+0
-   +ldaSCII "d"
-   sta stringBuffer+1
-   ldx #2
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   +cmpASCII ":"
-   beq +
-   iny
-   inx
-   bne -
-+  lda #0
-   sta stringBuffer,x
-   cpx #2
-   beq chdirSetName
-   lda chdirDevice
-   jsr cmdchOpen
-   bcc +
-   rts
-+  jsr cmdchSend
-   bcs chdirAbort
-   jsr checkDiskStatus
-   bcs chdirAbort
-   ldx chdirDevice  ;cmdchClose needs .X=device, not leftover X
-   jsr cmdchClose
-   lda #0
-   sta stringBuffer+2
++  +jmpMio mioChdirPath
 
-   chdirSetName = *
+;-- chdirSetName: commit chdirDevice as the new current directory; shared by
+;   the IEC path (mioChdirPath, acemioc64.asm) and pidChDir (acepid.asm)
+;   ( chdirDevice=set ) : .CC
+chdirSetName = *
    lda chdirDevice
    sta aceCurrentDevice
    lsr
@@ -1494,49 +902,10 @@ internDirChange = *
    clc
    rts
 
-   chdirAbort = *
-   ldx chdirDevice  ;cmdchClose needs .X=device, not leftover X
-   jsr cmdchClose
-   sec
-   rts
-
 ;*** aceIecCommand( (zp)=Command )
 
 kernIecCommand = *
-   ldx #0
-   ldy #0
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   iny
-   inx
-   bne -
-+  ldx aceCurrentDevice
-   lda configBuf+0,x
-   cmp #1
-   beq +
-   sec
-   rts
-+  lda aceCurrentDevice
-   jsr cmdchOpen
-   bcs ++
-   jsr cmdchSend
-   bcs +
-   ;read device response
-   ldx #cmdlf
-   jsr kernelChkin
--  jsr kernelChrin
-   pha
-   jsr kernConPutchar
-   pla
-   cmp #13
-   bne -
-   clc
-+  php
-   ldx aceCurrentDevice  ;cmdchClose needs .X=device, not leftover X
-   jsr cmdchClose
-   plp
-++ rts
+   +jmpMio mioIecCommand
 
 ;*** aceDirName( .A=sysdir, (zp)=buf, .Y=assignLen ) : buf, .Y=len
 ;***   .A : 0=curDir, 1=homedir, 2=execSearchPath, 3=configSearchPath, 4=tempDir

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -6,8 +6,6 @@
 ;
 ; Main file/dir/other system calls
 
-kernelSetbnk = $ff68
-
 ;====== file calls ======
 
 ;*** open( zp=filenameZ, .A=mode["r","w","a","W","A"] ) : .A=fcb
@@ -168,76 +166,16 @@ internOpen = *
    ;** get rid of the filename for non-disks
    nonDiskOpen = *
    ldx #0
-
-   openGotName = *
-   ;** dispatch here for non-kernel devices
-   txa
-   ldx #<stringBuffer
-   ldy #>stringBuffer
-   jsr kernelSetnam
-
-   ;set lfs
-   ldx openFcb
-   lda lftable,x
-   pha
-   lda satable,x
-   tay
-   lda devtable,x
-   tax
-   lda configBuf+1,x
-   tax
-   pla
-   jsr kernelSetlfs
-
-   ;do the open
-   jsr kernelOpen
-   bcs openError
-   ldx openDevice
-   lda configBuf+0,x
-   cmp #1
-   bne openSuccess
-   txa
-   jsr mioOpenDiskStatus
-   bcc openSuccess
-
-   openError = *
-   sta errno
-   ldx openFcb
-   lda lftable,x
-   clc
-   jsr kernelClose
-   ldx openFcb
-   lda #lfnull
-   sta lftable,x
-   sec
-   lda #fcbNull
-   rts
-   openSuccess = *
-   lda openFcb
-   clc
-   rts
+   jmp mioOpenGotName
 
 cmdchClose = *  ;( .X=device, matches cmdchOpen's convention )
    lda configBuf+0,x
    cmp #1
-   beq cmdchClosePhysical
-   lda configBuf+2,x
+   bne +
+   jmp mioCmdchClose
++  lda configBuf+2,x
    sta closeFd
    jmp pidClose
-   cmdchClosePhysical = *
-!if useIec {
-   sec
-   lda #cmdlf
-   jsr kernelClose
-   bcc +
-   sta errno
-+  rts
-} else {
-   lda #aceErrIllegalDevice
-   sta errno
-   sec
-   rts
-}
 
 
 ;NAME   :  close
@@ -363,17 +301,6 @@ kernFileRead = *
    clc
    rts
 +  jmp mioReadPath
-
-   readExit = *
-   jsr kernelClrchn
-   readExitNoclr = *
-   lda readLength+0
-   ldy readLength+1
-   sta zw+0
-   sty zw+1
-   ldx #$ff
-   clc
-   rts
 
    readEofExit = *
    lda #0

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -19,12 +19,10 @@ aceOpenOverwrite = *
    cpy #aceErrFileExists
    beq +
    sec
-   rts
+-  rts
 +  jsr internRemove
-   bcs +
-   +ldaSCII "w"
-   jsr open
-+  rts
+   bcs -
+   bcc aceOpenWrite   ;.CC guaranteed here (fell through bcs above), effectively 2-byte jmp
 
 aceOpenForceAppend = *
    +ldaSCII "a"
@@ -33,12 +31,13 @@ aceOpenForceAppend = *
    rts
 +  ldy errno
    cpy #aceErrFileNotFound
-   beq +
+   beq aceOpenWrite
    sec
    rts
-+  +ldaSCII "w"
-   jsr open
-   rts
+
+aceOpenWrite = *
+   +ldaSCII "w"
+   jmp kernFileOpen
 
 ;NAME   :  open
 ;PURPOSE:  open a file
@@ -130,7 +129,7 @@ internOpen = *
    bcc +
    jmp -
    ;** check mem-mapper files
-+ cmp #5
++  cmp #5
    bne +
    jmp internTagOpen
    ;** check virtual console

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -98,13 +98,11 @@ internOpen = *
    jmp nonDiskSa
 +  ldy #0
    ;** check native disk device
-!if useIec {
    cmp #1
    bne +
    jmp mioOpenDiskSa
-+  }
    ;** check console
-   cmp #2
++  cmp #2
    bne +
 -  lda openFcb
    clc
@@ -194,7 +192,6 @@ internOpen = *
    ;do the open
    jsr kernelOpen
    bcs openError
-!if useIec {
    ldx openDevice
    lda configBuf+0,x
    cmp #1
@@ -202,9 +199,6 @@ internOpen = *
    txa
    jsr mioOpenDiskStatus
    bcc openSuccess
-} else {
-   jmp openSuccess
-}
 
    openError = *
    sta errno
@@ -339,8 +333,7 @@ kernFileRead = *
    lda eoftable,x
    beq +
    jmp readEofExit
-+  ldy #0
-   lda devtable,x
++  lda devtable,x
    tax
    lda configBuf+0,x
    ; IDUN: Check idun virtual devices (type #4-7)
@@ -369,12 +362,7 @@ kernFileRead = *
    sty zw+1
    clc
    rts
-+  !if useIec {
-   cmp #1
-   bne +
-   ldy #$ff
-+  }
-   jmp mioReadPath
++  jmp mioReadPath
 
    readExit = *
    jsr kernelClrchn
@@ -581,7 +569,7 @@ internBload = *
 +  cmp #5
    bne +
    jmp internTagBload
-   cmp #1
++  cmp #1
    bne +
    jmp mioBloadPath
 +  lda #aceErrIllegalDevice
@@ -746,15 +734,10 @@ kernDirOpen = *
    rts
 +  sta openDevice
    sty openNameScan
-!if useIec {
    cpx #1               ;IEC device?
    bne +                ;no: virtual
-   +ldaSCII "$"
-   sta stringBuffer+0
-   ldx #1
-   jmp mioDirOpen
-+  }
-   jsr fcbSetup         ;virtual: allocate FCB then dispatch
+   jmp mioDirOpenRoot
++  jsr fcbSetup         ;virtual: allocate FCB then dispatch
    bcc +
    rts
 +  jmp pidDirOpen

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -229,14 +229,14 @@ kernFileRead = *
    cmp #2
    bcs +
    jmp mioReadPath
-   ;** check console
+   ;** check #2 console
 +  cmp #2
    bne +
    lda readMaxLen+0
    ldy readMaxLen+1
    ldx readFcb
    jmp conRead
-   ;** check null device
+   ;** check #3 null device
 +  cmp #3
    bne +
    lda #0
@@ -289,15 +289,11 @@ internWrite = *
    lda devtable,x
    tax
    lda configBuf+0,x
-   ; IDUN: Virtual disks (type #4, 7). Replace with acepid.
-   cmp #4
-   bne +
-   ldx regsave+1
-   jmp pidWrite
-+  cmp #7
-   bcc +
-   ldx regsave+1
-   jmp pidWrite
+   ;** #0-#1 go to mio
+   cmp #2
+   bcs +
+   jmp mioWritePath
+   ;** check console
 +  cmp #2
    bne +
    lda writeLength+0
@@ -309,7 +305,15 @@ internWrite = *
    bne +
    clc
    rts
-+  jmp mioWritePath
+   ;** #5-#6: mem-mapper files/virtual console, neither implemented for write;
++  cmp #5
+   bcc +
+   cmp #7
+   bcs +
+   jmp rtsErrIllegalDevice
+   ;** everything else (type #4, #7+) goes to pidWrite
++  ldx regsave+1
+   jmp pidWrite
 
 ;NAME   :  seek
 ;PURPOSE:  seek to file location

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -347,7 +347,10 @@ kernFileLseek = *
 ;RETURNS:  .CS  = error occurred flag
 ;ALTERS :  .A, .X, .Y, errno
 
-removeDevice = syswork+0
+removeDevice = syswork+0  ;== renameDevice/chdirDevice below -- acemiocbm.asm's
+                           ;mioCmdchTransact relies on this shared location to
+                           ;fold its open/send/status/close tail across
+                           ;mioRemovePath, mioRenamePath and mioChdirPath
 ;openNameScan(syswork+1) is set below too, then reused by mioCheckDiskStatus
 ;for its status code once mioRemovePath has consumed it -- see acemiocbm.asm
 
@@ -373,7 +376,8 @@ internRemove = *
 ;RETURNS:  .CS  = error occurred flag
 ;ALTERS :  .A, .X, .Y, errno
 
-renameDevice = syswork+0
+renameDevice = syswork+0  ;== removeDevice above/chdirDevice below -- see the
+                           ;mioCmdchTransact note at removeDevice's definition
 ;openNameScan(syswork+1) is set below too, then reused by mioCheckDiskStatus
 ;for its status code once mioRenamePath has consumed it -- see acemiocbm.asm
 
@@ -457,6 +461,14 @@ internBload = *
 ;*** aceDirStat ( .A=stat, (zp)=path ) : CS=error,errno
 ;                                .CC=filled aceSharedBuf
 
+miscInfoDevice = syswork+1  ;kernMiscDeviceInfo's (below) returned device
+                            ;number; every caller (here, kernFileStat, and
+                            ;mioFileStat in acemiocbm.asm) reads it right
+                            ;back out before this slot goes back to being
+                            ;openNameScan/chdirNameScan. Defined here, ahead
+                            ;of kernMiscDeviceInfo's own definition, so ACME
+                            ;sees it as zero page from its first use instead
+                            ;of sizing a forward-referenced load as absolute
 kernDirStat = *
    ldx #"/"
    cmp #$80
@@ -466,7 +478,7 @@ kernDirStat = *
    jsr kernMiscDeviceInfo
    bcs +
    jmp rtsErrIllegalDevice
-+  lda syswork+1
++  lda miscInfoDevice
    sta openDevice
    lda #"r"
    sta openMode
@@ -498,7 +510,7 @@ dstatRespHandler = *
 kernFileStat = *
    jsr kernMiscDeviceInfo
    bcc mioFileStatEntry
-   lda syswork+1
+   lda miscInfoDevice
    sta openDevice
    lda #"r"
    sta openMode
@@ -683,7 +695,8 @@ kernDirIsdir = *
 
 ;*** aceDirChange( (zp)=DirName, .A=flags($80=home,$40=parent) )
 
-chdirDevice = syswork+0
+chdirDevice = syswork+0  ;== removeDevice/renameDevice above -- see the
+                          ;mioCmdchTransact note at removeDevice's definition
 chdirNameScan = syswork+1  ;reused by mioCheckDiskStatus for its status code
                             ;once mioChdirPath has consumed it -- see acemiocbm.asm
 chdirParent !byte $5f,0
@@ -1030,10 +1043,11 @@ kernMiscSysType = *
 
 ;*** aceMiscDeviceInfo( (zp)=path: .A=iec addr,.X=type,.Y=scan pos
 ;                                  sw=flags,sw+1=device,.CS=virt.drv )
+;   ( miscInfoDevice=sw+1 is aliased above, ahead of kernDirStat )
 kernMiscDeviceInfo = *
    jsr getDevice
    sty syswork+2
-   sta syswork+1
+   sta miscInfoDevice
    tay
    lda configBuf+3,y
    sta syswork+0

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -6,6 +6,10 @@
 ;
 ; Main file/dir/other system calls
 
+rtsErrIllegalDevice = *
+   lda #aceErrIllegalDevice
+   jmp rtsCarryErrno
+
 ;====== file calls ======
 
 ;*** open( zp=filenameZ, .A=mode["r","w","a","W","A"] ) : .A=fcb
@@ -221,24 +225,18 @@ kernFileRead = *
 +  lda devtable,x
    tax
    lda configBuf+0,x
-   ; IDUN: Check idun virtual devices (type #4-7)
-   ;** check virtual disk
-   cmp #4
-   bne +
-   jmp pidRead
-+  cmp #7
-   bcc +
-   jmp pidRead
-   ;** check mem-mapper files
-+  cmp #5
-   bne +
-   jmp internTagRead
+   ;** #0-#1 go to mio
+   cmp #2
+   bcs +
+   jmp mioReadPath
+   ;** check console
 +  cmp #2
    bne +
    lda readMaxLen+0
    ldy readMaxLen+1
    ldx readFcb
    jmp conRead
+   ;** check null device
 +  cmp #3
    bne +
    lda #0
@@ -247,7 +245,16 @@ kernFileRead = *
    sty zw+1
    clc
    rts
-+  jmp mioReadPath
+   ;** check mem-mapper files
++  cmp #5
+   bne +
+   jmp internTagRead
+   ;** check virtual console -- not implemented for read
++  cmp #6
+   bne +
+   jmp rtsErrIllegalDevice
+   ;** IDUN virtual devices (type #4, #7+); nothing else can reach here
++  jmp pidRead
 
    readEofExit = *
    lda #0

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -338,8 +338,7 @@ kernFileLseek = *
    bne lseekIllegal
    jmp internTagSeek
    lseekIllegal = *
-   lda #aceErrIllegalDevice
-   jmp rtsCarryErrno
+   jmp rtsErrIllegalDevice
 
 
 ;NAME   :  aceFileRemove
@@ -453,8 +452,7 @@ internBload = *
 +  cmp #1
    bne +
    jmp mioBloadPath
-+  lda #aceErrIllegalDevice
-   jmp rtsCarryErrno
++  jmp rtsErrIllegalDevice
 
 ;*** aceDirStat ( .A=stat, (zp)=path ) : CS=error,errno
 ;                                .CC=filled aceSharedBuf
@@ -467,8 +465,7 @@ kernDirStat = *
 +  stx cmdPrefix
    jsr kernMiscDeviceInfo
    bcs +
-   lda #aceErrIllegalDevice
-   jmp rtsCarryErrno
+   jmp rtsErrIllegalDevice
 +  lda syswork+1
    sta openDevice
    lda #"r"

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -48,7 +48,7 @@ aceOpenWrite = *
 ;ALTERS :  .X, .Y, errno
 
 openFcb      = syswork+0
-openNameScan = syswork+1  ;mioCheckDiskStatus (acemioc64.asm) reuses this byte
+openNameScan = syswork+1  ;mioCheckDiskStatus (acemiocbm.asm) reuses this byte
                           ;for its parsed status code once the name scan is done
 openMode     = syswork+2
 openNameLength = syswork+3
@@ -390,7 +390,7 @@ kernFileLseek = *
 
 removeDevice = syswork+0
 ;openNameScan(syswork+1) is set below too, then reused by mioCheckDiskStatus
-;for its status code once mioRemovePath has consumed it -- see acemioc64.asm
+;for its status code once mioRemovePath has consumed it -- see acemiocbm.asm
 
 ;*** aceFileRemove( (zp)=Name )
 kernFileRemove = *
@@ -416,7 +416,7 @@ internRemove = *
 
 renameDevice = syswork+0
 ;openNameScan(syswork+1) is set below too, then reused by mioCheckDiskStatus
-;for its status code once mioRenamePath has consumed it -- see acemioc64.asm
+;for its status code once mioRenamePath has consumed it -- see acemiocbm.asm
 
 ;*** aceFileRename( (zp)=OldName, (zw)=NewName )
 ;*** don't even think about renaming files outside the current directory
@@ -570,7 +570,7 @@ fstatRespHandler = *
    ldy aceDirentBytes+1
    rts
 
-;-- fstatFcb: scratch shared with mioFileStat (acemioc64.asm); kernDirRead
+;-- fstatFcb: scratch shared with mioFileStat (acemiocbm.asm); kernDirRead
 ;   does not touch syswork+3
 fstatFcb = syswork+3
 mioFileStatEntry = *
@@ -728,7 +728,7 @@ kernDirIsdir = *
 
 chdirDevice = syswork+0
 chdirNameScan = syswork+1  ;reused by mioCheckDiskStatus for its status code
-                            ;once mioChdirPath has consumed it -- see acemioc64.asm
+                            ;once mioChdirPath has consumed it -- see acemiocbm.asm
 chdirParent !byte $5f,0
 
 kernDirChange = *
@@ -761,7 +761,7 @@ internDirChange = *
 +  jmp mioChdirPath
 
 ;-- chdirSetName: commit chdirDevice as the new current directory; shared by
-;   the IEC path (mioChdirPath, acemioc64.asm) and pidChDir (acepid.asm)
+;   the IEC path (mioChdirPath, acemiocbm.asm) and pidChDir (acepid.asm)
 ;   ( chdirDevice=set ) : .CC
 chdirSetName = *
    lda chdirDevice

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -139,9 +139,7 @@ internOpen = *
    jmp pidOpen
    ;** illegal device
 +  lda #aceErrIllegalDevice
-   sta errno
-   sec
-   rts
+   jmp rtsCarryErrno
 
    nonDiskSa = *
    ldx openFcb
@@ -381,9 +379,7 @@ kernFileLseek = *
    jmp internTagSeek
    lseekIllegal = *
    lda #aceErrIllegalDevice
-   sta errno
-   sec
-   rts
+   jmp rtsCarryErrno
 
 
 ;NAME   :  aceFileRemove
@@ -481,9 +477,7 @@ internBload = *
    lda (bloadFilename),y
    bne +
    lda #aceErrFileNotFound
-   sta errno
-   sec
-   rts
+   jmp rtsCarryErrno
 +  lda configBuf+0,x
    ; IDUN: Load from RAM disk replaced with acepid.
    cmp #4
@@ -500,9 +494,7 @@ internBload = *
    bne +
    jmp mioBloadPath
 +  lda #aceErrIllegalDevice
-   sta errno
-   sec
-   rts
+   jmp rtsCarryErrno
 
 ;*** aceDirStat ( .A=stat, (zp)=path ) : CS=error,errno
 ;                                .CC=filled aceSharedBuf
@@ -516,9 +508,7 @@ kernDirStat = *
    jsr kernMiscDeviceInfo
    bcs +
    lda #aceErrIllegalDevice
-   sta errno
-   sec
-   rts
+   jmp rtsCarryErrno
 +  lda syswork+1
    sta openDevice
    lda #"r"
@@ -1234,9 +1224,7 @@ getFcb = *
    cpx #fcbCount
    bcc -
    lda #aceErrTooManyFiles
-   sta errno
-   sec
-   rts
+   jmp rtsCarryErrno
 +  lda aceProcessID
    sta pidtable,x
    rts
@@ -1283,9 +1271,7 @@ getDiskDevice = *  ;( (zp)=devname ) : .A=device, .Y=scan, .X=dev_t, .CC=isDisk
    pla
    pla
    lda #aceErrDiskOnlyOperation
-   sta errno
-   sec
-   rts
+   jmp rtsCarryErrno
 
 
 ;┌────────────────────────────────────────────────────────────────────────┐

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -203,33 +203,22 @@ internClose = *
    stx closeFd
    internCloseCont = *
    lda configBuf+0,y
+   ;** #0-#1 go to mio
    cmp #2
-   bne +
-   jmp closeFdEntry
-+  cmp #3
-   bne +
-   jmp closeFdEntry
-   ; IDUN: Check idun virtual devices (type #4-7)
-   ;** check virtual disk
+   bcs +
+   jmp mioClosePath
+   ;** #2-#3 just close entry
 +  cmp #4
-   bne +
-   jsr pidClose
-   jmp closeFdEntry
-+  cmp #7
-   bcc +
-   jsr pidClose
-   jmp closeFdEntry
+   bcs +
+   bcc closeFdEntry ;.CC guaranteed here (fell through bcs above), effectively 2-byte jmp
    ;** check mem-mapper files
 +  cmp #5
    bne +
    jsr internTagClose
    jmp closeFdEntry
-   ;** check virtual console
-+  cmp #6
-   bne +
-   jsr pidClose
-   jmp closeFdEntry
-+  jmp mioClosePath
+   ;** IDUN virtual devices by now (type >=#4 except #5, including #6 virtual console)
++  jsr pidClose
+   ; fall through to closeFdEntry
 
    closeFdEntry = *
    ldx closeFd

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -1055,31 +1055,6 @@ kernMiscUtoa = *
    iny
    rts
 
-;*** aceMiscIoPeek( (zw)=ioaddr, .Y=offset ) : .A=data
-
-kernMiscIoPeek = *
-   lda #bkKernel
-   sta bkSelect
-   lda (zw),y
-   pha
-   lda #bkApp
-   sta bkSelect
-   pla
-   rts
-
-;*** aceMiscIoPoke( (zw)=ioaddr, .Y=offset, .A=data )
-
-kernMiscIoPoke = *
-   pha
-   lda #bkKernel
-   sta bkSelect
-   pla
-   sta (zw),y
-   pha
-   lda #bkApp
-   sta bkSelect
-   pla
-   rts
 
 ;*** aceMiscSysType () : .A=model, .X=int. banks, .Y=ERAM banks
 ;                        .sw+0=vdc mem.

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -48,7 +48,8 @@ aceOpenWrite = *
 ;ALTERS :  .X, .Y, errno
 
 openFcb      = syswork+0
-openNameScan = syswork+1
+openNameScan = syswork+1  ;mioCheckDiskStatus (acemioc64.asm) reuses this byte
+                          ;for its parsed status code once the name scan is done
 openMode     = syswork+2
 openNameLength = syswork+3
 openDevice   = syswork+4
@@ -392,6 +393,8 @@ kernFileLseek = *
 ;ALTERS :  .A, .X, .Y, errno
 
 removeDevice = syswork+0
+;openNameScan(syswork+1) is set below too, then reused by mioCheckDiskStatus
+;for its status code once mioRemovePath has consumed it -- see acemioc64.asm
 
 ;*** aceFileRemove( (zp)=Name )
 kernFileRemove = *
@@ -416,6 +419,8 @@ internRemove = *
 ;ALTERS :  .A, .X, .Y, errno
 
 renameDevice = syswork+0
+;openNameScan(syswork+1) is set below too, then reused by mioCheckDiskStatus
+;for its status code once mioRenamePath has consumed it -- see acemioc64.asm
 
 ;*** aceFileRename( (zp)=OldName, (zw)=NewName )
 ;*** don't even think about renaming files outside the current directory
@@ -732,7 +737,8 @@ kernDirIsdir = *
 ;*** aceDirChange( (zp)=DirName, .A=flags($80=home,$40=parent) )
 
 chdirDevice = syswork+0
-chdirNameScan = syswork+1
+chdirNameScan = syswork+1  ;reused by mioCheckDiskStatus for its status code
+                            ;once mioChdirPath has consumed it -- see acemioc64.asm
 chdirParent !byte $5f,0
 
 kernDirChange = *

--- a/cbm/sys/acecall.asm
+++ b/cbm/sys/acecall.asm
@@ -76,6 +76,7 @@ internOpen = *
 ++ jsr getLfAndFcb
    bcc fileOpenCont
    rts
+
    fileOpenCont = *
    sta lftable,x
    lda #$00
@@ -90,29 +91,27 @@ internOpen = *
    tax
    ;get sa here
    lda configBuf+0,x
-   cmp #0
-   bne +
-   ldy configBuf+2,x
-   jmp nonDiskSa
-+  ldy #0
-   ;** check native disk device
-   cmp #1
-   bne +
-   jmp mioOpenDiskSa
-   ;** check console
-+  cmp #2
-   bne +
--  lda openFcb
-   clc
+   ;** #0-#1 go to mio
+   cmp #2
+   bcs +
+   jmp mioOpenSa
+   ;** #2-#3: nothing else to do, just return the fcb
++  cmp #4
+   bcs +
+   lda openFcb
+   ;clc not needed -- carry is guaranteed clear here (fell through bcs above)
    rts
-   ;** check null device
-+  cmp #3
-   beq -
-   ; IDUN: Check idun virtual devices (type #4-7)
-   ;** check virtual disk
-   cmp #4
-   bne +++
--  ldx openFcb
+   ;** check mem-mapper files
++  cmp #5
+   bne +
+   jmp internTagOpen
+   ;** check virtual console
++  cmp #6
+   bne +
+   jmp pidOpen
+   ; IDUN: type #4 and #7+ share this cmdlf/regsave dispatch --
+   ; nothing else can reach here (0-3,5,6 all handled above)
++  ldx openFcb
    lda lftable,x
    cmp #cmdlf
    bne ++
@@ -126,45 +125,6 @@ internOpen = *
 +  lda regsave+1
    rts
 ++ jmp pidOpen
-+++cmp #7
-   bcc +
-   jmp -
-   ;** check mem-mapper files
-+  cmp #5
-   bne +
-   jmp internTagOpen
-   ;** check virtual console
-+  cmp #6
-   bne +
-   jmp pidOpen
-   ;** illegal device
-+  lda #aceErrIllegalDevice
-   jmp rtsCarryErrno
-
-   nonDiskSa = *
-   ldx openFcb
-   tya
-   sta satable,x
-
-   ;set the name
-   ldx #0
-   ldy openNameScan
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   iny
-   inx
-   bne -
-+  ldy openDevice
-   lda configBuf+0,y
-   cmp #1
-   bne nonDiskOpen
-   jmp mioOpenNameSuffix
-
-   ;** get rid of the filename for non-disks
-   nonDiskOpen = *
-   ldx #0
-   jmp mioOpenGotName
 
 cmdchClose = *  ;( .X=device, matches cmdchOpen's convention )
    lda configBuf+0,x

--- a/cbm/sys/acemacro.asm
+++ b/cbm/sys/acemacro.asm
@@ -63,3 +63,8 @@
 	asl
 	asl
 }
+;*** jumps to a mio-only (IEC drive) routine; when useIec=0, sys/acemionone.asm
+;*** aliases .label to mioUnsupported, so this always resolves to a valid jump
+!macro jmpMio .label {
+	jmp .label
+}

--- a/cbm/sys/acemacro.asm
+++ b/cbm/sys/acemacro.asm
@@ -63,8 +63,3 @@
 	asl
 	asl
 }
-;*** jumps to a mio-only (IEC drive) routine; when useIec=0, sys/acemionone.asm
-;*** aliases .label to mioUnsupported, so this always resolves to a valid jump
-!macro jmpMio .label {
-	jmp .label
-}

--- a/cbm/sys/acemioc64.asm
+++ b/cbm/sys/acemioc64.asm
@@ -1,0 +1,750 @@
+; Idun Kernel, Copyright ©2023 Brian Holdsworth
+; This is free software, released under the MIT License.
+;
+; IEC (serial-bus) physical disk drive support, extracted from acecall.asm.
+; Only assembled when useIec=1 (see sys/ace.asm). Every routine here talks
+; to the real KERNAL device I/O (kernelOpen/kernelClose/kernelChkin/
+; kernelChrin/kernelChrout) and/or the disk drive's command channel.
+;
+; Shared-dispatch call sites in acecall.asm reach these routines via the
+; +jmpMio macro (sys/acemacro.asm). When useIec=0, sys/acemionone.asm is
+; sourced instead of this file and aliases each of these entry point names
+; to mioUnsupported, so +jmpMio's `jmp .label` still resolves to something
+; (ACME evaluates macro arguments eagerly, so the label must be defined in
+; every build, not just conditionally jumped to).
+
+;-- mioOpenDiskSa: secondary-address search/assignment for physical disk opens
+;   ( openDevice=set, openFcb=set ) : .Y=sa, falls into nonDiskSa (acecall.asm)
+mioOpenDiskSa = *
+   lda #true
+   sta checkStat
+   ldy #2
+   diskSaSearch = *
+   ldx #fcbCount-1
+-  lda lftable,x
+   bmi +
+   lda devtable,x
+   cmp openDevice
+   bne +
+   tya
+   cmp satable,x
+   bne +
+   iny
+   bne diskSaSearch
++  dex
+   bpl -
+   jmp nonDiskSa
+
+;-- mioOpenNameSuffix: append ",<mode>" for physical disk file opens
+;   ( .X=name length in stringBuffer, openMode=set ) : jmp openGotName (acecall.asm)
+mioOpenNameSuffix = *
+   ;** stick the mode for disk files
+   cpx #0
+   bne +
+   lda #aceErrOpenDirectory
+   sec
+   rts
++  +ldaSCII ","
+   sta stringBuffer,x
+   inx
+   lda openMode
+   sta stringBuffer,x
+   inx
+   lda #0
+   sta stringBuffer,x
+   jmp openGotName
+
+;-- mioOpenDiskStatus: verify disk drive status after open/bload
+;   ( .A=device, checkStat=flag ) : errno=.A=errcode, .CS=errflag
+mioOpenDiskStatus = *
+   bit checkStat
+   bne +
+   clc
+   rts
++  sta mioDiskStatusDev ;temp. store device here!
+   jsr mioCmdchOpen
+   bcc +
+   cmp #aceErrFileOpen
+   bne ++
++  jsr mioCheckDiskStatus
+   php
+   pha
+   ldx mioDiskStatusDev
+   jsr cmdchClose
+   pla
+   plp
+++ rts
+mioDiskStatusDev !byte 0
+
+mioCmdchOpen = *  ;( .A=device )
+   tax
+   lda configBuf+2,x
+   tay
+   lda configBuf+1,x
+   tax
+   lda #cmdlf
+   jsr kernelSetlfs
+   lda #0
+   jsr kernelSetnam
+   jsr kernelOpen
+   bcc +
+   sta errno
++  rts
+
+mioCmdchSend = *  ;( stringBuffer )
+   ldx #cmdlf
+   jsr kernelChkout
+   bcs mioCmdchErr
+   ldx #0
+-  lda stringBuffer,x
+   beq +
+   jsr kernelChrout
+   bcs mioCmdchErr
+   inx
+   bne -
++  jsr kernelClrchn
+   clc
+   rts
+
+   mioCmdchErr = *
+   sta errno
+   pha
+   jsr kernelClrchn
+   pla
+   sec
+   rts
+
+mioCheckDiskStatusCode !byte 0
+
+mioCheckDiskStatus = *
+   ldx #cmdlf
+   jsr kernelChkin
+   bcs mioCmdchErr
+   jsr kernelChrin
+   bcs mioCmdchErr
+   and #$0f
+   sta mioCheckDiskStatusCode
+   asl
+   asl
+   adc mioCheckDiskStatusCode
+   asl
+   sta mioCheckDiskStatusCode
+   jsr kernelChrin
+   bcs mioCmdchErr
+   and #$0f
+   clc
+   adc mioCheckDiskStatusCode
+   sta mioCheckDiskStatusCode
+-  jsr kernelReadst
+   and #$80
+   beq +
+   lda #aceErrDeviceNotPresent
+   sec
+   bcs mioCmdchErr
++  jsr kernelChrin
+   bcs mioCmdchErr
+   cmp #chrCR
+   bne -
+   jsr kernelClrchn
+   lda mioCheckDiskStatusCode
+   cmp #62
+   bne +
+   lda #aceErrFileNotFound
+   sta errno
+   sec
+   rts
++  cmp #20
+   bcc +
+   sta errno
+   ;carry already set: bcc above didn't branch, so C=1 from the cmp #20
++  rts
+
+;-- mioClosePath: physical KERNAL close, for fds not owned by pid/tag/console
+;   ( closeFd=set ) : jmp closeFdEntry (acecall.asm)
+mioClosePath = *
+   ldx closeFd
+   lda lftable,x
+   clc
+   jsr kernelClose
+   jmp closeFdEntry
+
+;-- mioReadPath: physical KERNAL byte-at-a-time read, for fds not owned by
+;   pid/tag/console (.Y=$ff for disk fds, else 0 -- see readDeviceDisk)
+;   ( readFcb=set ) : jmp readExit (acecall.asm)
+mioReadPath = *
+   ldx readFcb
+   sty readDeviceDisk
+   lda lftable,x
+   tax
+   jsr kernelChkin
+   bcc mioReadByte
+   sta errno
+   rts
+
+   mioReadByte = *
+   lda readLength+0
+   cmp readMaxLen+0
+   lda readLength+1
+   sbc readMaxLen+1
+   bcc +
+   jmp readExit
++  jsr kernelChrin
+   ldy #0
+   sta (readPtr),y
+   inc readPtr+0
+   bne +
+   inc readPtr+1
++  inc readLength+0
+   bne +
+   inc readLength+1
++  bit readDeviceDisk
+   bpl mioReadByte
+   lda st
+   and #$40
+   beq mioReadByte
+   ldx readFcb
+   sta eoftable,x
+   jmp readExit
+
+;-- mioWritePath: physical KERNAL byte-at-a-time write, for fds not owned by
+;   pid/console/null
+;   ( regsave+1=fcb, writeLength/writePtr=set ) : .CS=error
+mioWritePath = *
+   ldx regsave+1
+   lda lftable,x
+   tax
+   jsr kernelChkout
+   bcc mioWriteByte
+   rts
+
+   mioWriteByte = *
+   lda writeLength+0
+   ora writeLength+1
+   beq mioWriteFinish
+   ldy #0
+   lda (writePtr),y
+   jsr kernelChrout
+   bcc +
+   sta errno
+   jsr kernelClrchn
+   sec
+   rts
++  inc writePtr+0
+   bne +
+   inc writePtr+1
++  lda writeLength+0
+   bne +
+   dec writeLength+1
++  dec writeLength+0
+   jmp mioWriteByte
+
+   mioWriteFinish = *
+   jsr kernelClrchn
+   clc
+   rts
+
+;-- mioBloadPath: physical KERNAL binary load, disk devices (type #1) only
+;   ( bloadDevice/bloadFilename/bloadAddress/bloadBank/checkStat=set )
+;   : .AY=End+1, .CS=error,errno
+mioBloadPath = *
+   lda #true
+   sta checkStat
+   lda configBuf+1,x
+   tax
+   lda #0
+   ldy #0
+   jsr kernelSetlfs
+   ldy #0
+-  lda (bloadFilename),y
+   beq +
+   iny
+   bne -
++  tya
+   ldx bloadFilename+0
+   ldy bloadFilename+1
+   jsr kernelSetnam
+!if useC128 {
+   lda bloadBank
+   beq +
+   ldx #0
+   jsr kernelSetbnk
+}
++  lda #0
+   ldx bloadAddress+0
+   ldy bloadAddress+1
+   jsr kernelLoad
+   bcc mioBloadOk
+   pha
+   cmp #aceErrDeviceNotPresent
+   beq +
+   ldx bloadDevice
+   lda configBuf+0,x
+   cmp #1
+   bne +
+   txa
+   jsr mioOpenDiskStatus
++  pla
+-  sta errno
+   lda #0
+   ldx #0
+   ldy #0
+   sec
+   rts
+
+   mioBloadOk = *
+   ldx bloadDevice
+   lda configBuf+0,x
+   cmp #1
+   bne +
+   txa
+   jsr mioOpenDiskStatus
+   bcs -
++  lda bloadAddress+0
+   ldy bloadAddress+1
+   rts
+
+;-- mioRemovePath: send "s0:name" over the command channel, check status
+;   ( removeDevice=set, openNameScan=set, (zp)=path ) : .CS=error,errno
+mioRemovePath = *
+   +ldaSCII "s"
+   sta stringBuffer
+   +ldaSCII ":"
+   sta stringBuffer+1
+   ldx #1
+   ldy openNameScan
+   lda (zp),y
+   +cmpASCII "/"
+   beq mioRemoveSlash
+   ldx #2
+mioRemoveSlash:
+   lda (zp),y
+   sta stringBuffer,x
+   beq +
+   iny
+   inx
+   bne mioRemoveSlash
++  lda #0
+   sta stringBuffer,x
+   lda removeDevice
+   jsr mioCmdchOpen
+   bcs ++
+   jsr mioCmdchSend
+   bcs +
+   jsr mioCheckDiskStatus
++  php
+   ldx removeDevice   ;cmdchClose needs .X=device, not leftover X
+   jsr cmdchClose
+   plp
+++ rts
+
+;-- mioRenamePath: send "r:new=old" over the command channel, check status
+;   ( renameDevice=set, renameScan=set, (zp)=old, (zw)=new ) : .CS=error,errno
+mioRenamePath = *
+   +ldaSCII "r"
+   sta stringBuffer+0
+   +ldaSCII ":"
+   sta stringBuffer+1
+   ;** copy new name
+   ldy #0
+   ldx #2
+-  lda (zw),y
+   sta stringBuffer,x
+   beq +
+   iny
+   inx
+   bne -
++  +ldaSCII "="
+   sta stringBuffer,x
+   inx
+   ;** copy old name
+   ldy renameScan
+-  lda (zp),y
+   sta stringBuffer,x
+   beq +
+   inx
+   iny
+   bne -
++  lda renameDevice
+   jsr mioCmdchOpen
+   bcs ++
+   jsr mioCmdchSend
+   bcs +
+   jsr mioCheckDiskStatus
++  php
+   ldx renameDevice  ;cmdchClose needs .X=device, not leftover X
+   jsr cmdchClose
+   plp
+++ rts
+
+;-- mioFileStat: IEC path for aceFileStat
+;   opens filtered dir "$:BASENAME", reads one entry into aceDirentBuffer
+;   ( syswork+1=device, (zp)=path ) : .AY=file size,.CS=error,errno
+mioFileStat = *
+   +ldaSCII "$"
+   sta stringBuffer+0
+   +ldaSCII ":"
+   sta stringBuffer+1
+   ldy #0
+-  lda (zp),y
+   beq mioFileStatNotFound
+   iny
+   cmp #<":"
+   bne -
+   ldx #2
+-  lda (zp),y
+   sta stringBuffer,x
+   beq +
+   iny
+   inx
+   bne -
++  lda syswork+1
+   sta openDevice
+   jsr mioDirOpen      ; .A = fcb
+   bcs mioFileStatRts
+   sta fstatFcb        ; kernDirRead clobbers openFcb=syswork+0 via dirBlocks
+   tax
+   jsr kernDirRead    ; skip disk name header entry
+   ldx fstatFcb
+   jsr kernDirRead    ; read actual file entry
+   php
+   lda fstatFcb
+   jsr kernDirClose
+   plp
+   bcs mioFileStatRts
+   bne +
+mioFileStatNotFound = *
+   lda #aceErrFileNotFound
+   sta errno
+mioFileStatRts = *
+   sec
+   rts
++  clc
+   rts
+
+;-- mioDirOpen: open IEC filtered dir with pre-built name in stringBuffer
+;   ( openDevice=set, .X=name length ) : .A=fd, .CC
+mioDirOpen = *
+   stx openNameLength
+   jsr fcbSetup
+   bcc +
+   rts
++  lda #true
+   sta checkStat
+   lda openDevice
+   jsr mioOpenDiskStatus
+   ldx openNameLength
+   jsr openGotName
+   bcc +
+   rts
++  ldx openFcb
+   lda lftable,x
+   tax
+   jsr kernelChkin
+   jsr kernelChrin
+   jsr kernelChrin
+   jsr kernelClrchn
+   lda openFcb
+   clc
+   rts
+
+;-- mioChdirPath: send "cd:name" over the command channel, check status
+;   ( chdirDevice=set, chdirNameScan=set(.Y), (zp)=dirname ) : .CS=error
+mioChdirPath = *
+   +ldaSCII "c"
+   sta stringBuffer+0
+   +ldaSCII "d"
+   sta stringBuffer+1
+   ldx #2
+-  lda (zp),y
+   sta stringBuffer,x
+   beq +
+   +cmpASCII ":"
+   beq +
+   iny
+   inx
+   bne -
++  lda #0
+   sta stringBuffer,x
+   cpx #2
+   bne +
+   jmp chdirSetName
++  lda chdirDevice
+   jsr mioCmdchOpen
+   bcc +
+   rts
++  jsr mioCmdchSend
+   bcs mioChdirAbort
+   jsr mioCheckDiskStatus
+   bcs mioChdirAbort
+   ldx chdirDevice  ;cmdchClose needs .X=device, not leftover X
+   jsr cmdchClose
+   lda #0
+   sta stringBuffer+2
+   jmp chdirSetName
+
+   mioChdirAbort = *
+   ldx chdirDevice  ;cmdchClose needs .X=device, not leftover X
+   jsr cmdchClose
+   sec
+   rts
+
+;-- mioIecCommand: aceIecCommand( (zp)=Command ), send raw DOS command
+;   string to the current device's command channel
+mioIecCommand = *
+   ldx #0
+   ldy #0
+-  lda (zp),y
+   sta stringBuffer,x
+   beq +
+   iny
+   inx
+   bne -
++  ldx aceCurrentDevice
+   lda configBuf+0,x
+   cmp #1
+   beq +
+   sec
+   rts
++  lda aceCurrentDevice
+   jsr mioCmdchOpen
+   bcs ++
+   jsr mioCmdchSend
+   bcs +
+   ;read device response
+   ldx #cmdlf
+   jsr kernelChkin
+-  jsr kernelChrin
+   pha
+   jsr kernConPutchar
+   pla
+   cmp #13
+   bne -
+   clc
++  php
+   ldx aceCurrentDevice  ;cmdchClose needs .X=device, not leftover X
+   jsr cmdchClose
+   plp
+++ rts
+
+;-- mioDirRead: read one BASIC-style directory listing entry from the
+;   command channel into aceDirentBuffer/aceDirentBytes
+;   ( .X=fcb, aceDirentBytes already zeroed by kernDirRead ) : .Z=eof
+dirBlocks = syswork+0
+mioDirRead = *
+   lda lftable,x
+   tax
+   jsr kernelChkin
+   bcc +
+   lda #0
+   rts
+   ;** read the link
++  jsr kernelChrin
+   sta syswork+4
+   jsr kernelReadst
+   and #$40
+   bne mioDirreadEofExit
+   jsr kernelChrin
+   ora syswork+4
+   bne +
+
+   mioDirreadEofExit = *
+   jsr kernelClrchn
+   ldx #0
+   rts
+   mioDirreadErrExit = *
+   sta errno
+   jsr kernelClrchn
+   ldx #0
+   sec
+   rts
+
+   ;** read the block count
++  jsr kernelChrin
+   sta dirBlocks
+   sta aceDirentBytes+1
+   jsr kernelChrin
+   sta dirBlocks+1
+   sta aceDirentBytes+2
+   asl dirBlocks
+   rol dirBlocks+1
+   lda #0
+   rol
+   sta dirBlocks+2
+   sec
+   lda #0
+   sbc dirBlocks
+   sta aceDirentBytes+0
+   lda aceDirentBytes+1
+   sbc dirBlocks+1
+   sta aceDirentBytes+1
+   lda aceDirentBytes+2
+   sbc dirBlocks+2
+   sta aceDirentBytes+2
+   ;** read the filename
+   lda #0
+   sta aceDirentName
+   sta aceDirentNameLen
+-  jsr kernelChrin
+   bcs mioDirreadErrExit
+   bit st
+   bvs mioDirreadErrExit
+   +cmpASCII " "
+   beq -
+   cmp #18
+   beq -
+   cmp #$22
+   bne mioDirreadExit
+   ldx #0
+-  jsr kernelChrin
+   bcs mioDirreadErrExit
+   bit st
+   bvs mioDirreadErrExit
+   cmp #$22
+   beq +
+   sta aceDirentName,x
+   inx
+   bne -
++  lda #0
+   sta aceDirentName,x
+   stx aceDirentNameLen
+-  jsr kernelChrin
+   +cmpASCII " "
+   beq -
+   ;** read type and flags
+   ldx #%01100000
+   stx aceDirentFlags
+   ldx #%10000000
+   stx aceDirentUsage
+   +cmpASCII "*"
+   bne +
+   lda aceDirentFlags
+   ora #%00001000
+   sta aceDirentFlags
+   jsr kernelChrin
++  ldx #3
+   ldy #0
+   jmp mioDirTypeFirst
+-  jsr kernelChrin
+   mioDirTypeFirst = *
+   sta aceDirentType,y
+   iny
+   dex
+   bne -
+   lda #0
+   sta aceDirentType+3
+   lda aceDirentType
+   +cmpASCII "d"
+   bne +
+   lda aceDirentFlags
+   ora #%10010000
+   sta aceDirentFlags
+   jmp mioDirreadExit
++  +cmpASCII "p"
+   bne mioDirreadExit
+   lda aceDirentFlags
+   ora #%00010000
+   sta aceDirentFlags
+   jmp mioDirreadExit
+
+   mioDirreadExit = *
+   jsr kernelChrin
+   cmp #0
+   bne +
+   jmp mioDirreadRealExit
++  +cmpASCII "<"
+   bne +
+   lda aceDirentFlags
+   and #%11011111
+   sta aceDirentFlags
++  ldx #7
+   lda #0
+-  sta aceDirentDate,x
+   dex
+   bpl -
+-  jsr kernelChrin
+   cmp #0
+   beq mioDirreadRealExit
+   +cmpASCII "0"
+   bcc -
+   cmp #$3a
+   bcs -
+
+   mioDirreadDate = *
+   jsr mioDirGetNumGot
+   bcs mioDirreadRealExit
+   sta aceDirentDate+2
+   jsr mioDirGetNum
+   bcs mioDirreadRealExit
+   sta aceDirentDate+3
+   jsr mioDirGetNum
+   bcs mioDirreadRealExit
+   sta aceDirentDate+1
+   ldx #$19
+   cmp #$70
+   bcs +
+   ldx #$20
++  stx aceDirentDate+0  ;century
+   jsr mioDirGetNum
+   bcs mioDirreadRealExit
+   sta aceDirentDate+4
+   jsr mioDirGetNum
+   bcs mioDirreadRealExit
+   sta aceDirentDate+5
+   jsr kernelChrin
+   and #$ff
+   beq mioDirreadRealExit
+   jsr kernelChrin
+   and #$ff
+   beq mioDirreadRealExit
+   +cmpASCII "a"
+   bne mioDirreadPM
+
+   mioDirreadAM = *
+   lda aceDirentDate+4
+   cmp #$12
+   bne +
+   lda #$00
+   sta aceDirentDate+4
+   jmp +
+
+   mioDirreadPM = *
+   lda aceDirentDate+4
+   cmp #$12
+   beq mioDirReadInternBr
+   clc
+   sed
+   adc #$12
+   cld
+   sta aceDirentDate+4
+mioDirReadInternBr:
+   jsr kernelChrin
+   cmp #0
+   bne mioDirReadInternBr
+
+   mioDirreadRealExit = *
+   jsr kernelClrchn
+   ldx #$ff
+   clc
+   rts
+
+   mioDirGetNum = *
+-  jsr kernelChrin
+   mioDirGetNumGot = *
+   cmp #0
+   beq +
+   +cmpASCII "0"
+   bcc -
+   cmp #$3a
+   bcs -
+   asl
+   asl
+   asl
+   asl
+   sta syswork+6
+   jsr kernelChrin
+   cmp #0
+   beq +
+   and #$0f
+   ora syswork+6
+   clc
++  rts

--- a/cbm/sys/acemioc64.asm
+++ b/cbm/sys/acemioc64.asm
@@ -168,10 +168,16 @@ mioClosePath = *
    jmp closeFdEntry
 
 ;-- mioReadPath: physical KERNAL byte-at-a-time read, for fds not owned by
-;   pid/tag/console (.Y=$ff for disk fds, else 0 -- see readDeviceDisk)
-;   ( readFcb=set ) : jmp readExit (acecall.asm)
+;   pid/tag/console. readDeviceDisk is set here from the device type: $ff
+;   for disk fds (watch KERNAL status for EOF), else 0 (read until the
+;   caller's requested length is satisfied, no EOF tracking)
+;   ( .A=device type, readFcb=set ) : jmp readExit (acecall.asm)
 mioReadPath = *
-   ldx readFcb
+   ldy #0
+   cmp #1
+   bne +
+   ldy #$ff
++  ldx readFcb
    sty readDeviceDisk
    lda lftable,x
    tax
@@ -419,6 +425,14 @@ mioFileStatRts = *
    rts
 +  clc
    rts
+
+;-- mioDirOpenRoot: open a physical drive's full directory listing
+;   ( openDevice=set ) : .A=fd, .CC -- falls into mioDirOpen below
+mioDirOpenRoot = *
+   +ldaSCII "$"          ; CBM DOS convention: filename "$" = directory listing
+   sta stringBuffer+0
+   ldx #1                ; name length = 1 (just "$")
+   ;** falls through into mioDirOpen -- no jmp needed, .X is already set up
 
 ;-- mioDirOpen: open IEC filtered dir with pre-built name in stringBuffer
 ;   ( openDevice=set, .X=name length ) : .A=fd, .CC

--- a/cbm/sys/acemioc64.asm
+++ b/cbm/sys/acemioc64.asm
@@ -1,4 +1,4 @@
-; Idun Kernel, Copyright ©2023 Brian Holdsworth
+; Idun Kernel, Copyright ©2026 Brian Holdsworth
 ; This is free software, released under the MIT License.
 ;
 ; IEC (serial-bus) physical disk drive support, extracted from acecall.asm.
@@ -6,12 +6,11 @@
 ; to the real KERNAL device I/O (kernelOpen/kernelClose/kernelChkin/
 ; kernelChrin/kernelChrout) and/or the disk drive's command channel.
 ;
-; Shared-dispatch call sites in acecall.asm reach these routines via the
-; +jmpMio macro (sys/acemacro.asm). When useIec=0, sys/acemionone.asm is
-; sourced instead of this file and aliases each of these entry point names
-; to mioUnsupported, so +jmpMio's `jmp .label` still resolves to something
-; (ACME evaluates macro arguments eagerly, so the label must be defined in
-; every build, not just conditionally jumped to).
+; Shared-dispatch call sites in acecall.asm reach these routines with a
+; plain `jmp mioXxx`. When useIec=0, sys/acemionone.asm is sourced instead
+; of this file and aliases each of these entry point names to
+; mioUnsupported, so those jumps still resolve to something rather than an
+; undefined symbol.
 
 ;-- mioOpenDiskSa: secondary-address search/assignment for physical disk opens
 ;   ( openDevice=set, openFcb=set ) : .Y=sa, falls into nonDiskSa (acecall.asm)
@@ -338,7 +337,7 @@ mioRemoveSlash:
 ++ rts
 
 ;-- mioRenamePath: send "r:new=old" over the command channel, check status
-;   ( renameDevice=set, renameScan=set, (zp)=old, (zw)=new ) : .CS=error,errno
+;   ( renameDevice=set, openNameScan=set, (zp)=old, (zw)=new ) : .CS=error,errno
 mioRenamePath = *
    +ldaSCII "r"
    sta stringBuffer+0
@@ -357,7 +356,7 @@ mioRenamePath = *
    sta stringBuffer,x
    inx
    ;** copy old name
-   ldy renameScan
+   ldy openNameScan
 -  lda (zp),y
    sta stringBuffer,x
    beq +

--- a/cbm/sys/acemioc64.asm
+++ b/cbm/sys/acemioc64.asm
@@ -35,7 +35,7 @@ mioOpenDiskSa = *
    jmp nonDiskSa
 
 ;-- mioOpenNameSuffix: append ",<mode>" for physical disk file opens
-;   ( .X=name length in stringBuffer, openMode=set ) : jmp openGotName (acecall.asm)
+;   ( .X=name length in stringBuffer, openMode=set ) : falls into mioOpenGotName
 mioOpenNameSuffix = *
    ;** stick the mode for disk files
    cpx #0
@@ -51,7 +51,58 @@ mioOpenNameSuffix = *
    inx
    lda #0
    sta stringBuffer,x
-   jmp openGotName
+   ;** falls through into mioOpenGotName -- no jmp needed
+
+;-- mioOpenGotName: perform the actual physical KERNAL open, given a fully
+;   built name (possibly zero-length) in stringBuffer
+;   ( .X=name length, openFcb/openDevice=set ) : .A=fcb,.CC or errno,.CS
+mioOpenGotName = *
+   ;** dispatch here for non-kernel devices
+   txa
+   ldx #<stringBuffer
+   ldy #>stringBuffer
+   jsr kernelSetnam
+
+   ;set lfs
+   ldx openFcb
+   lda lftable,x
+   pha
+   lda satable,x
+   tay
+   lda devtable,x
+   tax
+   lda configBuf+1,x
+   tax
+   pla
+   jsr kernelSetlfs
+
+   ;do the open
+   jsr kernelOpen
+   bcs mioOpenError
+   ldx openDevice
+   lda configBuf+0,x
+   cmp #1
+   bne mioOpenSuccess
+   txa
+   jsr mioOpenDiskStatus
+   bcc mioOpenSuccess
+
+   mioOpenError = *
+   sta errno
+   ldx openFcb
+   lda lftable,x
+   clc
+   jsr kernelClose
+   ldx openFcb
+   lda #lfnull
+   sta lftable,x
+   sec
+   lda #fcbNull
+   rts
+   mioOpenSuccess = *
+   lda openFcb
+   clc
+   rts
 
 ;-- mioOpenDiskStatus: verify disk drive status after open/bload
 ;   ( .A=device, checkStat=flag ) : errno=.A=errcode, .CS=errflag
@@ -86,6 +137,16 @@ mioCmdchOpen = *  ;( .A=device )
    lda #0
    jsr kernelSetnam
    jsr kernelOpen
+   bcc +
+   sta errno
++  rts
+
+;-- mioCmdchClose: physical KERNAL close of a device's command channel
+;   ( .X=device, matches mioCmdchOpen's convention ) : .CS=error,errno
+mioCmdchClose = *
+   sec
+   lda #cmdlf
+   jsr kernelClose
    bcc +
    sta errno
 +  rts
@@ -171,7 +232,7 @@ mioClosePath = *
 ;   pid/tag/console. readDeviceDisk is set here from the device type: $ff
 ;   for disk fds (watch KERNAL status for EOF), else 0 (read until the
 ;   caller's requested length is satisfied, no EOF tracking)
-;   ( .A=device type, readFcb=set ) : jmp readExit (acecall.asm)
+;   ( .A=device type, readFcb=set ) : falls into mioReadExit below on exit
 mioReadPath = *
    ldy #0
    cmp #1
@@ -192,7 +253,7 @@ mioReadPath = *
    lda readLength+1
    sbc readMaxLen+1
    bcc +
-   jmp readExit
+   jmp mioReadExit
 +  jsr kernelChrin
    ldy #0
    sta (readPtr),y
@@ -209,7 +270,18 @@ mioReadPath = *
    beq mioReadByte
    ldx readFcb
    sta eoftable,x
-   jmp readExit
+   ;** falls through into mioReadExit -- no jmp needed
+
+   mioReadExit = *
+   jsr kernelClrchn
+   mioReadExitNoclr = *
+   lda readLength+0
+   ldy readLength+1
+   sta zw+0
+   sty zw+1
+   ldx #$ff
+   clc
+   rts
 
 ;-- mioWritePath: physical KERNAL byte-at-a-time write, for fds not owned by
 ;   pid/console/null
@@ -446,7 +518,7 @@ mioDirOpen = *
    lda openDevice
    jsr mioOpenDiskStatus
    ldx openNameLength
-   jsr openGotName
+   jsr mioOpenGotName
    bcc +
    rts
 +  ldx openFcb

--- a/cbm/sys/acemioc64.asm
+++ b/cbm/sys/acemioc64.asm
@@ -174,7 +174,13 @@ mioCmdchSend = *  ;( stringBuffer )
    sec
    rts
 
-mioCheckDiskStatusCode !byte 0
+;-- mioCheckDiskStatus: zero-page scratch. Reuses syswork+1 (openNameScan /
+;   chdirNameScan) for the parsed status code -- safe because every caller
+;   (mioOpenDiskStatus, mioRemovePath, mioRenamePath, mioChdirPath) has
+;   already fully consumed its syswork+1 name-scan value by the time it
+;   calls here. See the syswork+1 aliases in acecall.asm for the other side
+;   of this contract.
+mioCheckDiskStatusCode = syswork+1
 
 mioCheckDiskStatus = *
    ldx #cmdlf
@@ -196,8 +202,7 @@ mioCheckDiskStatus = *
    adc mioCheckDiskStatusCode
    sta mioCheckDiskStatusCode
 -  jsr kernelReadst
-   and #$80
-   beq +
+   bpl +           ;READST leaves N=bit7 of the status byte it just loaded
    lda #aceErrDeviceNotPresent
    sec
    bcs mioCmdchErr

--- a/cbm/sys/acemioc64.asm
+++ b/cbm/sys/acemioc64.asm
@@ -215,9 +215,7 @@ mioCheckDiskStatus = *
    cmp #62
    bne +
    lda #aceErrFileNotFound
-   sta errno
-   sec
-   rts
+   jmp rtsCarryErrno
 +  cmp #20
    bcc +
    sta errno

--- a/cbm/sys/acemiocbm.asm
+++ b/cbm/sys/acemiocbm.asm
@@ -9,8 +9,8 @@
 ; Shared-dispatch call sites in acecall.asm reach these routines with a
 ; plain `jmp mioXxx`. When useMioCbm=0, sys/acemionone.asm is sourced instead
 ; of this file and aliases each of these entry point names to
-; mioUnsupported, so those jumps still resolve to something rather than an
-; undefined symbol.
+; rtsErrIllegalDevice (acecall.asm), so those jumps still resolve to
+; something rather than an undefined symbol.
 
 ;-- mioOpenSa: entry point for type-0/type-1 opens (device type < 2); decide
 ;   the secondary address, then falls into mioNonDiskSa below

--- a/cbm/sys/acemiocbm.asm
+++ b/cbm/sys/acemiocbm.asm
@@ -2,12 +2,12 @@
 ; This is free software, released under the MIT License.
 ;
 ; IEC (serial-bus) physical disk drive support, extracted from acecall.asm.
-; Only assembled when useIec=1 (see sys/ace.asm). Every routine here talks
+; Only assembled when useMioCbm=1 (see sys/ace.asm). Every routine here talks
 ; to the real KERNAL device I/O (kernelOpen/kernelClose/kernelChkin/
 ; kernelChrin/kernelChrout) and/or the disk drive's command channel.
 ;
 ; Shared-dispatch call sites in acecall.asm reach these routines with a
-; plain `jmp mioXxx`. When useIec=0, sys/acemionone.asm is sourced instead
+; plain `jmp mioXxx`. When useMioCbm=0, sys/acemionone.asm is sourced instead
 ; of this file and aliases each of these entry point names to
 ; mioUnsupported, so those jumps still resolve to something rather than an
 ; undefined symbol.

--- a/cbm/sys/acemiocbm.asm
+++ b/cbm/sys/acemiocbm.asm
@@ -12,8 +12,18 @@
 ; mioUnsupported, so those jumps still resolve to something rather than an
 ; undefined symbol.
 
-;-- mioOpenDiskSa: secondary-address search/assignment for physical disk opens
-;   ( openDevice=set, openFcb=set ) : .Y=sa, falls into nonDiskSa (acecall.asm)
+;-- mioOpenSa: entry point for type-0/type-1 opens (device type < 2); decide
+;   the secondary address, then falls into mioNonDiskSa below
+;   ( .X=openDevice, .A=device type (0 or 1), openFcb=set ) : .Y=sa
+mioOpenSa = *
+   cmp #1
+   beq mioOpenDiskSa
+   ldy configBuf+2,x  ;type 0: fixed sa, configured per-device
+   jmp mioNonDiskSa
+
+;-- mioOpenDiskSa: secondary-address search/assignment for physical disk
+;   opens (type 1) -- falls into mioNonDiskSa below
+;   ( openDevice=set, openFcb=set ) : .Y=sa
 mioOpenDiskSa = *
    lda #true
    sta checkStat
@@ -32,7 +42,35 @@ mioOpenDiskSa = *
    bne diskSaSearch
 +  dex
    bpl -
-   jmp nonDiskSa
+   ;** falls through into mioNonDiskSa -- no jmp needed
+
+;-- mioNonDiskSa: store sa, build the filename, dispatch to the disk-suffix
+;   handling (type 1) or straight to the open (type 0)
+;   ( .Y=sa, openFcb/openNameScan=set, (zp)=path ) : falls into mioOpenGotName
+mioNonDiskSa = *
+   ldx openFcb
+   tya
+   sta satable,x
+
+   ;set the name
+   ldx #0
+   ldy openNameScan
+-  lda (zp),y
+   sta stringBuffer,x
+   beq +
+   iny
+   inx
+   bne -
++  ldy openDevice
+   lda configBuf+0,y
+   cmp #1
+   bne mioNonDiskOpen
+   jmp mioOpenNameSuffix
+
+   ;** get rid of the filename for non-disks
+   mioNonDiskOpen = *
+   ldx #0
+   jmp mioOpenGotName
 
 ;-- mioOpenNameSuffix: append ",<mode>" for physical disk file opens
 ;   ( .X=name length in stringBuffer, openMode=set ) : falls into mioOpenGotName

--- a/cbm/sys/acemiocbm.asm
+++ b/cbm/sys/acemiocbm.asm
@@ -158,7 +158,8 @@ mioOpenDiskStatus = *
    php
    pha
    ldx mioDiskStatusDev
-   jsr cmdchClose
+   jsr mioCmdchClose  ;checkStat is only ever true for type-1 devices, so the
+                      ;generic cmdchClose dispatch/type-recheck is unneeded
    pla
    plp
 ++ rts

--- a/cbm/sys/acemiocbm.asm
+++ b/cbm/sys/acemiocbm.asm
@@ -55,13 +55,8 @@ mioNonDiskSa = *
    ;set the name
    ldx #0
    ldy openNameScan
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   iny
-   inx
-   bne -
-+  ldy openDevice
+   jsr mioCopyNameZp
+   ldy openDevice
    lda configBuf+0,y
    cmp #1
    bne mioNonDiskOpen
@@ -118,11 +113,7 @@ mioOpenGotName = *
    jsr kernelOpen
    bcs mioOpenError
    ldx openDevice
-   lda configBuf+0,x
-   cmp #1
-   bne mioOpenSuccess
-   txa
-   jsr mioOpenDiskStatus
+   jsr mioTypeCheckDiskStatus
    bcc mioOpenSuccess
 
    mioOpenError = *
@@ -141,6 +132,20 @@ mioOpenGotName = *
    lda openFcb
    clc
    rts
+
+;-- mioCopyNameZp: copy a null-terminated string from (zp),Y into
+;   stringBuffer,X, starting at the caller's X/Y, until the terminator.
+;   Shared by mioNonDiskSa, mioRenamePath, mioFileStat and mioIecCommand,
+;   which all inlined this same loop to assemble a name/path
+;   ( .X=starting index, .Y=starting offset, (zp)=source ) : .X=index of nul
+mioCopyNameZp = *
+-  lda (zp),y
+   sta stringBuffer,x
+   beq +
+   iny
+   inx
+   bne -
++  rts
 
 ;-- mioOpenDiskStatus: verify disk drive status after open/bload
 ;   ( .A=device, checkStat=flag ) : errno=.A=errcode, .CS=errflag
@@ -164,6 +169,21 @@ mioOpenDiskStatus = *
    plp
 ++ rts
 mioDiskStatusDev !byte 0
+
+;-- mioTypeCheckDiskStatus: re-verify disk status for a device, but only if
+;   it actually is a physical disk (type 1); non-disk devices are a no-op
+;   success. Shared by mioOpenGotName and mioBloadPath -- both used to
+;   inline this same configBuf type test around a mioOpenDiskStatus call
+;   ( .X=device ) : .CS=error,errno (disk devices only) or .CC
+mioTypeCheckDiskStatus = *
+   lda configBuf+0,x
+   cmp #1
+   bne mioTypeCheckDiskStatusSkip
+   txa
+   jmp mioOpenDiskStatus   ;tail call: its rts returns to our caller
+   mioTypeCheckDiskStatusSkip = *
+   clc
+   rts
 
 mioCmdchOpen = *  ;( .A=device )
    tax
@@ -213,7 +233,7 @@ mioCmdchSend = *  ;( stringBuffer )
    sec
    rts
 
-;-- mioCheckDiskStatus: zero-page scratch. Reuses syswork+1 (openNameScan /
+;-- mioCheckDiskStatusCode: zero-page scratch. Reuses syswork+1 (openNameScan /
 ;   chdirNameScan) for the parsed status code -- safe because every caller
 ;   (mioOpenDiskStatus, mioRemovePath, mioRenamePath, mioChdirPath) has
 ;   already fully consumed its syswork+1 name-scan value by the time it
@@ -397,11 +417,7 @@ mioBloadPath = *
    cmp #aceErrDeviceNotPresent
    beq +
    ldx bloadDevice
-   lda configBuf+0,x
-   cmp #1
-   bne +
-   txa
-   jsr mioOpenDiskStatus
+   jsr mioTypeCheckDiskStatus
 +  pla
 -  sta errno
    lda #0
@@ -412,11 +428,7 @@ mioBloadPath = *
 
    mioBloadOk = *
    ldx bloadDevice
-   lda configBuf+0,x
-   cmp #1
-   bne +
-   txa
-   jsr mioOpenDiskStatus
+   jsr mioTypeCheckDiskStatus
    bcs -
 +  lda bloadAddress+0
    ldy bloadAddress+1
@@ -445,16 +457,7 @@ mioRemoveSlash:
 +  lda #0
    sta stringBuffer,x
    lda removeDevice
-   jsr mioCmdchOpen
-   bcs ++
-   jsr mioCmdchSend
-   bcs +
-   jsr mioCheckDiskStatus
-+  php
-   ldx removeDevice   ;cmdchClose needs .X=device, not leftover X
-   jsr cmdchClose
-   plp
-++ rts
+   jmp mioCmdchTransact
 
 ;-- mioRenamePath: send "r:new=old" over the command channel, check status
 ;   ( renameDevice=set, openNameScan=set, (zp)=old, (zw)=new ) : .CS=error,errno
@@ -477,27 +480,35 @@ mioRenamePath = *
    inx
    ;** copy old name
    ldy openNameScan
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   inx
-   iny
-   bne -
-+  lda renameDevice
+   jsr mioCopyNameZp
+   lda renameDevice
+   ;** falls through into mioCmdchTransact -- no jmp needed
+
+;-- mioCmdchTransact: open a device's command channel, send stringBuffer as
+;   a DOS command, check status, then close. Shared tail for mioRemovePath
+;   and mioRenamePath -- safe to fold together because removeDevice and
+;   renameDevice both alias syswork+0 (see acecall.asm). Placed directly
+;   after mioRenamePath so its call falls through instead of jmp'ing
+;   ( .A=device=syswork+0, stringBuffer=command ) : .CS=error,errno
+mioCmdchTransact = *
    jsr mioCmdchOpen
-   bcs ++
+   bcs mioCmdchTransactErr
    jsr mioCmdchSend
-   bcs +
+   bcs mioCmdchTransactClose
    jsr mioCheckDiskStatus
-+  php
-   ldx renameDevice  ;cmdchClose needs .X=device, not leftover X
+
+   mioCmdchTransactClose = *
+   php
+   ldx syswork+0
    jsr cmdchClose
    plp
-++ rts
+   
+   mioCmdchTransactErr = *
+   rts
 
 ;-- mioFileStat: IEC path for aceFileStat
 ;   opens filtered dir "$:BASENAME", reads one entry into aceDirentBuffer
-;   ( syswork+1=device, (zp)=path ) : .AY=file size,.CS=error,errno
+;   ( miscInfoDevice=device, (zp)=path ) : .AY=file size,.CS=error,errno
 mioFileStat = *
    +ldaSCII "$"
    sta stringBuffer+0
@@ -510,13 +521,8 @@ mioFileStat = *
    cmp #<":"
    bne -
    ldx #2
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   iny
-   inx
-   bne -
-+  lda syswork+1
+   jsr mioCopyNameZp
+   lda miscInfoDevice
    sta openDevice
    jsr mioDirOpen      ; .A = fcb
    bcs mioFileStatRts
@@ -596,37 +602,21 @@ mioChdirPath = *
    bne +
    jmp chdirSetName
 +  lda chdirDevice
-   jsr mioCmdchOpen
-   bcc +
-   rts
-+  jsr mioCmdchSend
-   bcs mioChdirAbort
-   jsr mioCheckDiskStatus
-   bcs mioChdirAbort
-   ldx chdirDevice  ;cmdchClose needs .X=device, not leftover X
-   jsr cmdchClose
+   jsr mioCmdchTransact  ;.CS,errno on open/send/status failure -- already
+                         ;closed the cmd channel either way, same as before
+   bcs +
    lda #0
    sta stringBuffer+2
    jmp chdirSetName
-
-   mioChdirAbort = *
-   ldx chdirDevice  ;cmdchClose needs .X=device, not leftover X
-   jsr cmdchClose
-   sec
-   rts
++  rts
 
 ;-- mioIecCommand: aceIecCommand( (zp)=Command ), send raw DOS command
 ;   string to the current device's command channel
 mioIecCommand = *
    ldx #0
    ldy #0
--  lda (zp),y
-   sta stringBuffer,x
-   beq +
-   iny
-   inx
-   bne -
-+  ldx aceCurrentDevice
+   jsr mioCopyNameZp
+   ldx aceCurrentDevice
    lda configBuf+0,x
    cmp #1
    beq +

--- a/cbm/sys/acemionone.asm
+++ b/cbm/sys/acemionone.asm
@@ -7,11 +7,10 @@
 ; with its own physical drive support would provide a sibling file (e.g.
 ; sys/acemiomega65.asm) instead of using this one.
 ;
-; Aliases every mio* entry point that acecall.asm's +jmpMio call sites
-; reference to mioUnsupported, so those macro calls -- which need a defined
-; label in every build, since ACME evaluates macro arguments eagerly --
-; still resolve, just straight to the "illegal device" error instead of
-; real drive code.
+; Aliases every mio* entry point that acecall.asm's shared dispatch code
+; reaches with a plain `jmp mioXxx` to mioUnsupported, so those jumps still
+; resolve to something -- straight to the "illegal device" error -- instead
+; of an undefined symbol.
 
 mioOpenNameSuffix = mioUnsupported
 mioClosePath      = mioUnsupported

--- a/cbm/sys/acemionone.asm
+++ b/cbm/sys/acemionone.asm
@@ -35,7 +35,26 @@ mioChdirPath      = mioUnsupported
 mioIecCommand     = mioUnsupported
 mioBloadPath      = mioUnsupported
 mioDirOpenRoot    = mioUnsupported
-mioOpenDiskSa     = mioUnsupported
+mioCmdchClose     = mioUnsupported
+
+;-- mioOpenUnsupported: like mioUnsupported, but also frees the fcb slot
+;   that kernFileOpen (acecall.asm) already claimed before reaching either
+;   mioOpenDiskSa or mioOpenGotName -- both run mid-open, after the fcb is
+;   allocated, so a plain mioUnsupported here would leak it (lftable would
+;   keep the slot marked in-use forever, since the code that frees it on
+;   failure never gets a chance to run)
+mioOpenUnsupported = *
+   ldx openFcb
+   lda #lfnull
+   sta lftable,x
+   lda #aceErrIllegalDevice
+   sta errno
+   sec
+   lda #fcbNull
+   rts
+
+mioOpenDiskSa  = mioOpenUnsupported
+mioOpenGotName = mioOpenUnsupported
 
 ;-- mioOpenDiskStatus: called (.A=device) after a device's open already
 ;   succeeded, to let a real drive implementation additionally verify

--- a/cbm/sys/acemionone.asm
+++ b/cbm/sys/acemionone.asm
@@ -1,4 +1,4 @@
-; Idun Kernel, Copyright ©2023 Brian Holdsworth
+; Idun Kernel, Copyright ©2026 Brian Holdsworth
 ; This is free software, released under the MIT License.
 ;
 ; Stand-in mio* implementation for platforms with no IEC/serial-bus drive
@@ -12,6 +12,17 @@
 ; resolve to something -- straight to the "illegal device" error -- instead
 ; of an undefined symbol.
 
+;-- mioUnsupported: fallback for shared dispatch code's plain `jmp mioXxx`
+;   sites when useIec=0 -- reached only if a device is (mis)configured as
+;   an IEC drive on a build with no IEC support. sys/acemionone.asm aliases
+;   every mio* entry point to this label when useIec=0, so those `jmp`s
+;   always resolve to something instead of an undefined symbol
+mioUnsupported = *
+   lda #aceErrIllegalDevice
+   sta errno
+   sec
+   rts
+
 mioOpenNameSuffix = mioUnsupported
 mioClosePath      = mioUnsupported
 mioReadPath       = mioUnsupported
@@ -22,3 +33,17 @@ mioFileStat       = mioUnsupported
 mioDirRead        = mioUnsupported
 mioChdirPath      = mioUnsupported
 mioIecCommand     = mioUnsupported
+mioBloadPath      = mioUnsupported
+mioDirOpenRoot    = mioUnsupported
+mioOpenDiskSa     = mioUnsupported
+
+;-- mioOpenDiskStatus: called (.A=device) after a device's open already
+;   succeeded, to let a real drive implementation additionally verify
+;   drive status; .CC=ok, .CS=errno set. Unlike the entry points above,
+;   this isn't an operation that inherently requires drive support -- it's
+;   an optional extra check on an already-successful open -- so with no
+;   drive implementation at all there's nothing to verify: always .CC=ok,
+;   not mioUnsupported's error.
+mioOpenDiskStatus = *
+   clc
+   rts

--- a/cbm/sys/acemionone.asm
+++ b/cbm/sys/acemionone.asm
@@ -1,0 +1,25 @@
+; Idun Kernel, Copyright ©2023 Brian Holdsworth
+; This is free software, released under the MIT License.
+;
+; Stand-in mio* implementation for platforms with no IEC/serial-bus drive
+; support at all (useIec=0, see sys/ace.asm) -- the "no drive" counterpart
+; to sys/acemioc64.asm's C64/128 IEC implementation. A future platform
+; with its own physical drive support would provide a sibling file (e.g.
+; sys/acemiomega65.asm) instead of using this one.
+;
+; Aliases every mio* entry point that acecall.asm's +jmpMio call sites
+; reference to mioUnsupported, so those macro calls -- which need a defined
+; label in every build, since ACME evaluates macro arguments eagerly --
+; still resolve, just straight to the "illegal device" error instead of
+; real drive code.
+
+mioOpenNameSuffix = mioUnsupported
+mioClosePath      = mioUnsupported
+mioReadPath       = mioUnsupported
+mioWritePath      = mioUnsupported
+mioRemovePath     = mioUnsupported
+mioRenamePath     = mioUnsupported
+mioFileStat       = mioUnsupported
+mioDirRead        = mioUnsupported
+mioChdirPath      = mioUnsupported
+mioIecCommand     = mioUnsupported

--- a/cbm/sys/acemionone.asm
+++ b/cbm/sys/acemionone.asm
@@ -39,7 +39,7 @@ mioCmdchClose     = mioUnsupported
 
 ;-- mioOpenUnsupported: like mioUnsupported, but also frees the fcb slot
 ;   that kernFileOpen (acecall.asm) already claimed before reaching either
-;   mioOpenDiskSa or mioOpenGotName -- both run mid-open, after the fcb is
+;   mioOpenSa or mioOpenGotName -- both run mid-open, after the fcb is
 ;   allocated, so a plain mioUnsupported here would leak it (lftable would
 ;   keep the slot marked in-use forever, since the code that frees it on
 ;   failure never gets a chance to run)
@@ -53,7 +53,7 @@ mioOpenUnsupported = *
    lda #fcbNull
    rts
 
-mioOpenDiskSa  = mioOpenUnsupported
+mioOpenSa      = mioOpenUnsupported
 mioOpenGotName = mioOpenUnsupported
 
 ;-- mioOpenDiskStatus: called (.A=device) after a device's open already

--- a/cbm/sys/acemionone.asm
+++ b/cbm/sys/acemionone.asm
@@ -8,39 +8,28 @@
 ; sys/acemiomega65.asm) instead of using this one.
 ;
 ; Aliases every mio* entry point that acecall.asm's shared dispatch code
-; reaches with a plain `jmp mioXxx` to mioUnsupported, so those jumps still
-; resolve to something -- straight to the "illegal device" error -- instead
-; of an undefined symbol.
+; reaches with a plain `jmp mioXxx` to rtsErrIllegalDevice (acecall.asm), so
+; those jumps still resolve to something -- straight to the "illegal device"
+; error -- instead of an undefined symbol.
 
-;-- mioUnsupported: fallback for shared dispatch code's plain `jmp mioXxx`
-;   sites when useMioCbm=0 -- reached only if a device is (mis)configured as
-;   an IEC drive on a build with no IEC support. sys/acemionone.asm aliases
-;   every mio* entry point to this label when useMioCbm=0, so those `jmp`s
-;   always resolve to something instead of an undefined symbol
-mioUnsupported = *
-   lda #aceErrIllegalDevice
-   sta errno
-   sec
-   rts
+mioOpenNameSuffix = rtsErrIllegalDevice
+mioClosePath      = rtsErrIllegalDevice
+mioReadPath       = rtsErrIllegalDevice
+mioWritePath      = rtsErrIllegalDevice
+mioRemovePath     = rtsErrIllegalDevice
+mioRenamePath     = rtsErrIllegalDevice
+mioFileStat       = rtsErrIllegalDevice
+mioDirRead        = rtsErrIllegalDevice
+mioChdirPath      = rtsErrIllegalDevice
+mioIecCommand     = rtsErrIllegalDevice
+mioBloadPath      = rtsErrIllegalDevice
+mioDirOpenRoot    = rtsErrIllegalDevice
+mioCmdchClose     = rtsErrIllegalDevice
 
-mioOpenNameSuffix = mioUnsupported
-mioClosePath      = mioUnsupported
-mioReadPath       = mioUnsupported
-mioWritePath      = mioUnsupported
-mioRemovePath     = mioUnsupported
-mioRenamePath     = mioUnsupported
-mioFileStat       = mioUnsupported
-mioDirRead        = mioUnsupported
-mioChdirPath      = mioUnsupported
-mioIecCommand     = mioUnsupported
-mioBloadPath      = mioUnsupported
-mioDirOpenRoot    = mioUnsupported
-mioCmdchClose     = mioUnsupported
-
-;-- mioOpenUnsupported: like mioUnsupported, but also frees the fcb slot
+;-- mioOpenUnsupported: like rtsErrIllegalDevice, but also frees the fcb slot
 ;   that kernFileOpen (acecall.asm) already claimed before reaching either
 ;   mioOpenSa or mioOpenGotName -- both run mid-open, after the fcb is
-;   allocated, so a plain mioUnsupported here would leak it (lftable would
+;   allocated, so rtsErrIllegalDevice here would leak it (lftable would
 ;   keep the slot marked in-use forever, since the code that frees it on
 ;   failure never gets a chance to run)
 mioOpenUnsupported = *
@@ -62,7 +51,7 @@ mioOpenGotName = mioOpenUnsupported
 ;   this isn't an operation that inherently requires drive support -- it's
 ;   an optional extra check on an already-successful open -- so with no
 ;   drive implementation at all there's nothing to verify: always .CC=ok,
-;   not mioUnsupported's error.
+;   not rtsErrIllegalDevice's error.
 mioOpenDiskStatus = *
    clc
    rts

--- a/cbm/sys/acemionone.asm
+++ b/cbm/sys/acemionone.asm
@@ -2,8 +2,8 @@
 ; This is free software, released under the MIT License.
 ;
 ; Stand-in mio* implementation for platforms with no IEC/serial-bus drive
-; support at all (useIec=0, see sys/ace.asm) -- the "no drive" counterpart
-; to sys/acemioc64.asm's C64/128 IEC implementation. A future platform
+; support at all (useMioCbm=0, see sys/ace.asm) -- the "no drive" counterpart
+; to sys/acemiocbm.asm's C64/128 IEC implementation. A future platform
 ; with its own physical drive support would provide a sibling file (e.g.
 ; sys/acemiomega65.asm) instead of using this one.
 ;
@@ -13,9 +13,9 @@
 ; of an undefined symbol.
 
 ;-- mioUnsupported: fallback for shared dispatch code's plain `jmp mioXxx`
-;   sites when useIec=0 -- reached only if a device is (mis)configured as
+;   sites when useMioCbm=0 -- reached only if a device is (mis)configured as
 ;   an IEC drive on a build with no IEC support. sys/acemionone.asm aliases
-;   every mio* entry point to this label when useIec=0, so those `jmp`s
+;   every mio* entry point to this label when useMioCbm=0, so those `jmp`s
 ;   always resolve to something instead of an undefined symbol
 mioUnsupported = *
    lda #aceErrIllegalDevice

--- a/doc/apiref.md
+++ b/doc/apiref.md
@@ -1488,30 +1488,6 @@ ALTERS :  .A, .X
 This is a utility call in the kernel.  It is really not necessary for it to be in the kernel, but so many programs make use of it that it makes sense for it to be factored out.  You give a pointer to a 32-bit unsigned value in zero page memory, a pointer to a buffer to store that string that is at least as long as necessary to store the value plus the null-character terminator that will be put on the end of the string, and a minimum length value for the string.  If the number requires fewer digits than the minimum length, the string will be padded with spaces on the left.  Since a 32-bit quantity can only contain an maximum of ten decimal digits, the string buffer will only need to be a maximum of eleven bytes in size.
 
 ```
-NAME   :  aceMiscIoPeek
-PURPOSE:  do a peek into the I/O space ($D000-$DFFF)
-ARGS   :  (zw) = I/O-space address
-          .Y   = offset from (zw)
-RETURNS:  .A   = peeked value
-          .CS  = error if operation not supported
-ALTERS :  <nothing>
-```
-
-Does a peek into the system I/O-address space.  This is a pretty ugly call, but you should use this rather than peeking into the space directly because application programs aren't supposed to directly peek into there at all.
-
-```
-NAME   :  aceMiscIoPoke
-PURPOSE:  do a peek into the I/O space ($D000-$DFFF)
-ARGS   :  (zw) = I/O-space address
-          .Y   = offset from (zw)
-          .A   = value to poke
-RETURNS:  .CS  = error if operation not supported
-ALTERS :  <nothing>
-```
-
-Does a poke into the system I/O-address space.  This is a pretty ugly call, but you should use this rather than poking into the space directly because application programs aren't supposed to directly peek into there at all.
-
-```
 NAME   :  aceTurboCtl
 PURPOSE:  control the turbo boost of the C64 Ultimate
 ARGS   :  .A   = index value for speed (0 to 15)


### PR DESCRIPTION
## Extract IEC/CBM-KERNAL drive support into a swappable `mio` module

### What changed

**New build flag `useMioCbm`** (`sys/ace.asm`, default `1`, override via `-DuseMioCbm=0`) selects which "machine I/O" implementation gets sourced after `acecall.asm`:

- `sys/acemiocbm.asm` (new, ~870 lines) — the real implementation for C64/128, moved wholesale out of `acecall.asm`. Every KERNAL call (`SETNAM`/`SETLFS`/`OPEN`/`CLOSE`/`CHKIN`/`CHRIN`/`CHKOUT`/`CHROUT`/`READST`) now lives here exclusively.
- `sys/acemionone.asm` (new) — the no-drive stand-in for `useMioCbm=0`. Every `mio*` entry point that `acecall.asm`'s dispatch reaches aliases directly to a shared `rtsErrIllegalDevice` stub, except `mioOpenDiskStatus` (returns "all good" — it's an optional post-open check, not an operation that inherently needs drive support) and `mioOpenSa`/`mioOpenGotName` (need to free the fcb slot they already claimed before failing, not just error out).
- Renamed from `acemioc64.asm` → `acemiocbm.asm` partway through, since the split is CBM-vs-none, not C64-vs-something — leaves room for a future `acemiomega65.asm` sibling with its own native drive support.

**Dispatch pattern**, applied throughout (`kernFileOpen/Close/Read/Write/Bload/Remove/Rename`, `kernDirOpen/Change/Read`, `kernIecCommand`): route CBM-drive device types to `mio*` via a plain `jmp`/`jsr`, relying on `acemionone.asm`'s aliasing to make that resolve safely even when the real implementation isn't compiled in. No `!if useMioCbm` conditionals remain in `acecall.asm` — an earlier macro-based approach (`jmpMio`) was tried and dropped once we found ACME evaluates macro arguments eagerly, which breaks when the argument is a label that plain doesn't exist in a `useMioCbm=0` build.

**Bugs fixed along the way** (found while reordering the dispatch chains, not the original goal):

- `kernFileRead`/`kernFileWrite`: type 6 (virtual TTY) had no explicit case and silently fell through to the real-KERNAL path meant for type 0/1 — now cleanly returns "illegal device" (type 6 is meant to go through the dedicated `aceTtyAvail`/`Get`/`Put` API, not generic read/write).
- `kernFileWrite`: type 5 (mem-mapped files) had the same fallthrough gap — `internTagWrite` doesn't exist, so it now also returns "illegal device" instead of silently misrouting.
- `kernFileOpen`/`kernFileClose`: type 8 ("user-defined application driver", e.g. the Unix-socket device) inconsistently fell to different fallbacks in different calls; now uniformly routed to the `pid*` (virtual-device) path like types 4/6/7, matching how `open`/`read`/`write` already treated it.
- A pre-existing dangling-anonymous-label bug in `kernFileLseek` (its `bne` had no matching local target and silently resolved into unrelated code further down the file) — given a real label.

**Byte-size cleanups**, applied consistently once the dispatch chains were already being touched:

- Device-type checks reordered so range checks (`cmp #N` / `bcc`/`bcs`) replace chains of individual equality checks wherever two or more types share an outcome (e.g. `kernFileOpen`'s "type 2 or 3 just return the fcb", `kernFileClose`'s "type 2 or 3 just clear the entry", `kernFileWrite`'s "type 5 or 6 are both illegal").
- Shared error-return stubs added and reused everywhere applicable: `rtsCarryErrno` (`sta errno`/`sec`/`rts`, now also the fallthrough tail of the existing `notImp` jump-table stub) and `rtsErrIllegalDevice` (`lda #aceErrIllegalDevice` falling into `rtsCarryErrno`), replacing dozens of inlined 4–5 byte copies of the same instructions.
- `mioCmdchTransact` added in `acemiocbm.asm` to deduplicate the "open command channel, send `stringBuffer`, check status, close channel" sequence shared by remove/rename/chdir.
- Several `syswork`-scratch aliasing cleanups (e.g. `chdirDevice`/`removeDevice`/`renameDevice` deliberately overlapping the same bytes, `renameScan` dropped in favor of reusing `openNameScan`) to avoid a wasted byte per call.
- `getDiskDevice` now bails callers out directly on non-disk devices, since every caller only ever used it for disk-only operations anyway.

**Removed**: `aceMiscIoPeek`/`aceMiscIoPoke` (unused, and awkward to support on a future non-memory-mapped-I/O platform) — jump-table slots kept as `notImp` stubs to preserve the table's fixed offsets/ABI, `doc/apiref.md` entries removed to match.

### Files touched

`Makefile`, `sys/ace.asm`, `sys/acecall.asm` (−1150/+~250 net), `sys/acemacro.asm` (trivial), `sys/acemiocbm.asm` (new, +867), `sys/acemionone.asm` (new, +57), `doc/apiref.md`.
